### PR TITLE
[codex] add structured server error logging

### DIFF
--- a/app/check-in/actions.ts
+++ b/app/check-in/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getSession } from '@/lib/auth/session';
+import { logServerError } from '@/lib/observability/logger';
 
 export async function toggleCheckIn(eventId: string, userId: string, isCheckingIn: boolean) {
   const session = await getSession();
@@ -42,7 +43,15 @@ export async function toggleCheckIn(eventId: string, userId: string, isCheckingI
     });
 
     if (error) {
-      console.error('Error checking in:', error);
+      logServerError({
+        scope: 'check_in.manual_in',
+        message: 'Error checking in',
+        error,
+        context: {
+          eventId,
+          userId,
+        },
+      });
       throw new Error('Failed to check in');
     }
   } else {
@@ -52,7 +61,15 @@ export async function toggleCheckIn(eventId: string, userId: string, isCheckingI
     });
 
     if (error) {
-      console.error('Error un-checking in:', error);
+      logServerError({
+        scope: 'check_in.manual_out',
+        message: 'Error un-checking in',
+        error,
+        context: {
+          eventId,
+          userId,
+        },
+      });
       throw new Error('Failed to un-check in');
     }
   }

--- a/app/inventory/actions.ts
+++ b/app/inventory/actions.ts
@@ -9,6 +9,7 @@ import {
   normalizeInventoryItemInput,
   normalizeInventoryMovementInput,
 } from '@/lib/inventory/inventory-utils';
+import { logServerError } from '@/lib/observability/logger';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 
 type InventoryStatus =
@@ -107,7 +108,15 @@ export async function createInventoryItem(formData: FormData) {
 
     redirectToInventory('item-created');
   } catch (error) {
-    console.error('Error creating inventory item:', error);
+    logServerError({
+      scope: 'inventory.create_item',
+      message: 'Error creating inventory item',
+      error,
+      context: {
+        itemName: String(formData.get('name') ?? ''),
+        sku: String(formData.get('sku') ?? ''),
+      },
+    });
     redirectToInventory(mapInventoryError(error));
   }
 }
@@ -161,7 +170,16 @@ export async function applyInventoryMovement(formData: FormData) {
 
     redirectToInventory(input.type === 'in' ? 'stock-in' : 'stock-out');
   } catch (error) {
-    console.error('Error applying inventory movement:', error);
+    logServerError({
+      scope: 'inventory.apply_movement',
+      message: 'Error applying inventory movement',
+      error,
+      context: {
+        itemId: String(formData.get('itemId') ?? ''),
+        movementType: String(formData.get('type') ?? ''),
+        quantity: String(formData.get('quantity') ?? ''),
+      },
+    });
     redirectToInventory(mapInventoryError(error));
   }
 }

--- a/app/tasks/actions.ts
+++ b/app/tasks/actions.ts
@@ -3,6 +3,7 @@
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { getSession } from '@/lib/auth/session';
+import { logServerError } from '@/lib/observability/logger';
 
 export async function updateTaskStatus(taskId: string, status: string) {
   const session = await getSession();
@@ -18,7 +19,15 @@ export async function updateTaskStatus(taskId: string, status: string) {
   const { error } = await supabase.from('tasks').update({ status }).eq('id', taskId);
 
   if (error) {
-    console.error('Error updating task status:', error);
+    logServerError({
+      scope: 'tasks.update_status',
+      message: 'Error updating task status',
+      error,
+      context: {
+        status,
+        taskId,
+      },
+    });
     throw new Error('Failed to update task status');
   }
 

--- a/lib/observability/logger.ts
+++ b/lib/observability/logger.ts
@@ -1,0 +1,131 @@
+type LogLevel = 'info' | 'error';
+
+type LogContext = Record<string, unknown>;
+
+type LogErrorInput = {
+  context?: LogContext;
+  error?: unknown;
+  message: string;
+  scope: string;
+};
+
+type SerializedError = {
+  code?: string;
+  details?: string;
+  hint?: string;
+  message: string;
+  name: string;
+  stack?: string;
+};
+
+type LogEntry = {
+  context: LogContext;
+  environment: string;
+  error?: SerializedError;
+  eventId: string;
+  level: LogLevel;
+  message: string;
+  scope: string;
+  timestamp: string;
+};
+
+const REDACTED_KEYS = ['authorization', 'cookie', 'key', 'password', 'secret', 'token'];
+
+function isRedactedKey(key: string) {
+  return REDACTED_KEYS.some((candidate) => key.toLowerCase().includes(candidate));
+}
+
+function sanitizeValue(value: unknown): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeValue(entry));
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, entry]) => [
+        key,
+        isRedactedKey(key) ? '[redacted]' : sanitizeValue(entry),
+      ])
+    );
+  }
+
+  return value;
+}
+
+function serializeError(error: unknown): SerializedError | undefined {
+  if (!error) {
+    return undefined;
+  }
+
+  if (error instanceof Error) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      ...(sanitizeValue(error) as Record<string, unknown>),
+    } as SerializedError;
+  }
+
+  if (typeof error === 'object') {
+    const record = sanitizeValue(error) as Record<string, unknown>;
+
+    return {
+      message: typeof record.message === 'string' ? record.message : 'Unknown error',
+      name: typeof record.name === 'string' ? record.name : 'Error',
+      code: typeof record.code === 'string' ? record.code : undefined,
+      details: typeof record.details === 'string' ? record.details : undefined,
+      hint: typeof record.hint === 'string' ? record.hint : undefined,
+    };
+  }
+
+  return {
+    message: String(error),
+    name: 'Error',
+  };
+}
+
+function buildLogEntry(level: LogLevel, input: LogErrorInput): LogEntry {
+  return {
+    context: (sanitizeValue(input.context ?? {}) as LogContext) ?? {},
+    environment: process.env.VERCEL_ENV ?? process.env.NODE_ENV ?? 'unknown',
+    error: serializeError(input.error),
+    eventId: crypto.randomUUID(),
+    level,
+    message: input.message,
+    scope: input.scope,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function emitLog(entry: LogEntry) {
+  const payload = JSON.stringify(entry);
+
+  if (entry.level === 'error') {
+    // eslint-disable-next-line no-console
+    console.error(payload);
+    return;
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(payload);
+}
+
+export function logServerError(input: LogErrorInput) {
+  const entry = buildLogEntry('error', input);
+  emitLog(entry);
+  return entry.eventId;
+}
+
+export function logServerInfo(input: Omit<LogErrorInput, 'error'>) {
+  const entry = buildLogEntry('info', input);
+  emitLog(entry);
+  return entry.eventId;
+}

--- a/tests/logger.test.ts
+++ b/tests/logger.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { logServerError } from '@/lib/observability/logger';
+
+describe('logServerError', () => {
+  it('emits structured logs with redacted sensitive fields', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    logServerError({
+      scope: 'inventory.create_item',
+      message: 'Inventory create failed',
+      context: {
+        actorEmail: 'staff@example.com',
+        apiKey: 'top-secret',
+        nested: {
+          accessToken: 'abc',
+        },
+      },
+      error: {
+        code: '23505',
+        details: 'duplicate key value violates unique constraint',
+        message: 'duplicate key value',
+      },
+    });
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+
+    const payload = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    expect(payload.scope).toBe('inventory.create_item');
+    expect(payload.message).toBe('Inventory create failed');
+    expect(payload.context.actorEmail).toBe('staff@example.com');
+    expect(payload.context.apiKey).toBe('[redacted]');
+    expect(payload.context.nested.accessToken).toBe('[redacted]');
+    expect(payload.error.code).toBe('23505');
+    expect(payload.eventId).toBeTypeOf('string');
+    expect(payload.timestamp).toBeTypeOf('string');
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary\n- add a minimal structured server logger for Next.js server actions\n- replace bare console.error calls in inventory, tasks, and check-in actions\n- add tests for log redaction and payload shape\n\n## Validation\n- pnpm test\n- pnpm lint\n- pnpm build\n- pnpm typecheck