### PR TITLE
Fix Supabase cookie refresh crash on root render

### DIFF
--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -24,9 +24,14 @@ export async function createSupabaseServerClient() {
           return cookieStore.getAll();
         },
         setAll(cookiesToSet: CookieToSet[]) {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options);
-          });
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options);
+            });
+          } catch {
+            // Server Components can read session cookies but cannot refresh them.
+            // Middleware already refreshes Supabase auth cookies before render.
+          }
         },
       },
     }


### PR DESCRIPTION
## Summary
- prevent Supabase auth cookie refresh attempts from crashing Server Component renders
- keep cookie refresh writes available where Next allows them, while middleware remains responsible for session refresh before render

## Evidence
- Vercel runtime logs showed digest 190695177 on GET / with: `Cookies can only be modified in a Server Action or Route Handler`

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build