### PR TITLE
Add stock search to inventory

### DIFF
--- a/app/inventory/actions.ts
+++ b/app/inventory/actions.ts
@@ -15,6 +15,7 @@ import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 export type InventoryStatus =
   | 'item-created'
   | 'item-deleted'
+  | 'history-cleared'
   | 'stock-in'
   | 'stock-out'
   | 'validation-error'
@@ -43,6 +44,7 @@ async function getInventoryActionContext() {
 
   return {
     supabase,
+    role: session.role,
     operatorName: session.displayName || session.email || 'Camp user',
   };
 }
@@ -130,6 +132,8 @@ export async function createInventoryItem(
 
     const { error: movementError } = await supabase.from('inventory_movements').insert({
       item_id: createdItem.id,
+      item_name: input.name,
+      item_sku: input.sku,
       type: 'in',
       quantity: 1,
       operator_name: operatorName,
@@ -175,12 +179,45 @@ export async function deleteInventoryItem(
       throw new Error('Item is required');
     }
 
-    const { supabase } = await getInventoryActionContext();
+    const { supabase, operatorName } = await getInventoryActionContext();
+
+    const { data: item, error: itemReadError } = await supabase
+      .from('inventory_items')
+      .select('name, sku')
+      .eq('id', itemId)
+      .single();
+
+    if (itemReadError) {
+      throw itemReadError;
+    }
+
+    const { data: stockRow, error: stockReadError } = await supabase
+      .from('inventory_stock')
+      .select('quantity')
+      .eq('item_id', itemId)
+      .maybeSingle();
+
+    if (stockReadError) {
+      throw stockReadError;
+    }
 
     const { error } = await supabase.from('inventory_items').delete().eq('id', itemId);
 
     if (error) {
       throw error;
+    }
+
+    const { error: movementError } = await supabase.from('inventory_movements').insert({
+      item_id: null,
+      item_name: item.name,
+      item_sku: item.sku,
+      type: 'delete',
+      quantity: stockRow?.quantity ?? 0,
+      operator_name: operatorName,
+    });
+
+    if (movementError) {
+      throw movementError;
     }
 
     revalidatePath('/inventory');
@@ -207,6 +244,43 @@ export async function deleteInventoryItem(
   }
 }
 
+export async function clearInventoryHistory(
+  _previousState: InventoryActionState,
+  _formData: FormData
+): Promise<InventoryActionState> {
+  try {
+    const { supabase, role } = await getInventoryActionContext();
+
+    if (role !== 'super_admin') {
+      throw new Error('Unauthorized');
+    }
+
+    const { error } = await supabase.from('inventory_movements').delete().not('id', 'is', null);
+
+    if (error) {
+      throw error;
+    }
+
+    revalidatePath('/inventory/history');
+
+    return {
+      status: 'history-cleared',
+      submittedAt: Date.now(),
+    };
+  } catch (error) {
+    logServerError({
+      scope: 'inventory.clear_history',
+      message: 'Error clearing inventory history',
+      error,
+    });
+
+    return {
+      status: mapInventoryError(error),
+      submittedAt: Date.now(),
+    };
+  }
+}
+
 export async function applyInventoryMovement(
   _previousState: InventoryActionState,
   formData: FormData
@@ -219,6 +293,16 @@ export async function applyInventoryMovement(
     });
 
     const { supabase, operatorName } = await getInventoryActionContext();
+
+    const { data: item, error: itemReadError } = await supabase
+      .from('inventory_items')
+      .select('name, sku')
+      .eq('id', input.itemId)
+      .single();
+
+    if (itemReadError) {
+      throw itemReadError;
+    }
 
     const { data: stockRow, error: stockReadError } = await supabase
       .from('inventory_stock')
@@ -248,6 +332,8 @@ export async function applyInventoryMovement(
 
     const { error: movementError } = await supabase.from('inventory_movements').insert({
       item_id: input.itemId,
+      item_name: item.name,
+      item_sku: item.sku,
       type: input.type,
       quantity: input.quantity,
       operator_name: operatorName,

--- a/app/inventory/history/clear-history-button.tsx
+++ b/app/inventory/history/clear-history-button.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { startTransition, useActionState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useFormStatus } from 'react-dom';
+
+import { getInventoryStatusMessage } from '@/lib/inventory/inventory-utils';
+
+import { clearInventoryHistory, type InventoryActionState } from '../actions';
+
+const initialInventoryActionState: InventoryActionState = {
+  status: null,
+  submittedAt: null,
+};
+
+function ClearSubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex items-center justify-center rounded-full border border-camp-forest/10 bg-camp-sand/35 px-4 py-2.5 text-sm font-semibold text-camp-forest transition hover:bg-camp-sand/55 disabled:cursor-wait disabled:opacity-70"
+    >
+      {pending ? 'Clearing...' : 'Clear history'}
+    </button>
+  );
+}
+
+export function ClearHistoryButton() {
+  const router = useRouter();
+  const [state, formAction] = useActionState(clearInventoryHistory, initialInventoryActionState);
+  const statusMessage = getInventoryStatusMessage(state.status ?? undefined);
+
+  useEffect(() => {
+    if (!state.submittedAt || state.status !== 'history-cleared') {
+      return;
+    }
+
+    startTransition(() => {
+      router.refresh();
+    });
+  }, [router, state.status, state.submittedAt]);
+
+  return (
+    <div className="grid gap-2 sm:justify-items-end">
+      {statusMessage ? (
+        <div
+          className={`rounded-[14px] border px-3 py-2 text-xs ${
+            statusMessage.tone === 'success'
+              ? 'border-emerald-200 bg-emerald-50/90 text-emerald-900'
+              : 'border-rose-200 bg-rose-50/90 text-rose-900'
+          }`}
+        >
+          {statusMessage.text}
+        </div>
+      ) : null}
+
+      <form
+        action={formAction}
+        onSubmit={(event) => {
+          if (!window.confirm('Clear all inventory history? This cannot be undone.')) {
+            event.preventDefault();
+          }
+        }}
+      >
+        <ClearSubmitButton />
+      </form>
+    </div>
+  );
+}

--- a/app/inventory/history/page.tsx
+++ b/app/inventory/history/page.tsx
@@ -11,6 +11,8 @@ import {
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
+import { ClearHistoryButton } from './clear-history-button';
+
 type InventoryHistoryBundle = {
   enabled: boolean;
   errors: string[];
@@ -34,7 +36,7 @@ async function loadInventoryHistory(): Promise<InventoryHistoryBundle> {
     supabase.from('inventory_items').select('id, name, sku'),
     supabase
       .from('inventory_movements')
-      .select('id, item_id, type, quantity, operator_name, time')
+      .select('id, item_id, item_name, item_sku, type, quantity, operator_name, time')
       .order('time', { ascending: false }),
   ]);
 
@@ -58,6 +60,26 @@ function formatDateTime(value: string) {
     hour: '2-digit',
     minute: '2-digit',
   }).format(new Date(value));
+}
+
+function movementClasses(type: string) {
+  if (type === 'in') {
+    return 'bg-emerald-100 text-emerald-900';
+  }
+
+  if (type === 'delete') {
+    return 'bg-camp-sand/70 text-camp-forest';
+  }
+
+  return 'bg-amber-100 text-amber-900';
+}
+
+function movementLabel(type: string) {
+  if (type === 'delete') {
+    return 'deleted';
+  }
+
+  return type;
 }
 
 export default async function InventoryHistoryPage() {
@@ -108,12 +130,15 @@ export default async function InventoryHistoryPage() {
                     Every inbound and outbound movement records the operator and time automatically.
                   </p>
                 </div>
-                <Link
-                  href="/inventory"
-                  className="inline-flex items-center justify-center rounded-full border border-camp-forest/15 px-4 py-2.5 text-sm font-semibold text-camp-forest transition hover:bg-camp-sand/35"
-                >
-                  Back to inventory
-                </Link>
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  {session.role === 'super_admin' ? <ClearHistoryButton /> : null}
+                  <Link
+                    href="/inventory"
+                    className="inline-flex items-center justify-center rounded-full border border-camp-forest/15 px-4 py-2.5 text-sm font-semibold text-camp-forest transition hover:bg-camp-sand/35"
+                  >
+                    Back to inventory
+                  </Link>
+                </div>
               </div>
 
               <div className="mt-5 grid gap-3">
@@ -123,7 +148,9 @@ export default async function InventoryHistoryPage() {
                   </div>
                 ) : (
                   history.movements.map((movement) => {
-                    const item = itemById.get(movement.item_id);
+                    const item = movement.item_id ? itemById.get(movement.item_id) : undefined;
+                    const itemName = item?.name ?? movement.item_name ?? 'Deleted item';
+                    const itemSku = item?.sku ?? movement.item_sku ?? 'DELETED';
 
                     return (
                       <article
@@ -133,24 +160,19 @@ export default async function InventoryHistoryPage() {
                         <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
                           <div>
                             <div className="flex flex-wrap items-center gap-2">
-                              <p className="font-semibold text-camp-forest">
-                                {item?.name ?? 'Unknown item'}
-                              </p>
+                              <p className="font-semibold text-camp-forest">{itemName}</p>
                               <span className="rounded-full bg-camp-sky/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] text-camp-forest">
-                                {item?.sku ?? 'UNKNOWN'}
+                                {itemSku}
                               </span>
                               <span
-                                className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${
-                                  movement.type === 'in'
-                                    ? 'bg-emerald-100 text-emerald-900'
-                                    : 'bg-amber-100 text-amber-900'
-                                }`}
+                                className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-[0.16em] ${movementClasses(movement.type)}`}
                               >
-                                {movement.type}
+                                {movementLabel(movement.type)}
                               </span>
                             </div>
                             <p className="mt-2 text-sm text-slate-700">
-                              Quantity: {movement.quantity}
+                              {movement.type === 'delete' ? 'Stock at delete' : 'Quantity'}:{' '}
+                              {movement.quantity}
                             </p>
                             <p className="mt-1 text-sm text-slate-600">
                               Operator: {movement.operator_name}

--- a/app/inventory/page.tsx
+++ b/app/inventory/page.tsx
@@ -14,8 +14,7 @@ import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 import { CreateItemForm } from './create-item-form';
-import { DeleteItemButton } from './delete-item-button';
-import { StockMovementForm } from './stock-movement-form';
+import { StockSearchList } from './stock-search-list';
 
 type InventoryPageProps = {
   searchParams: Promise<{
@@ -217,52 +216,7 @@ export default async function InventoryPage({ searchParams }: InventoryPageProps
                       No stock records yet.
                     </div>
                   ) : (
-                    stockItems.map((item) => (
-                      <article
-                        key={item.id}
-                        className="rounded-[24px] border border-camp-forest/10 bg-white p-4"
-                      >
-                        <div className="grid gap-3 xl:grid-cols-[minmax(120px,1fr)_112px_minmax(205px,1fr)_minmax(215px,1fr)_40px] xl:items-center">
-                          <div className="min-w-0">
-                            <p className="truncate text-lg font-semibold text-camp-forest">
-                              {item.name}
-                            </p>
-                            <span className="mt-1 inline-flex rounded-full bg-camp-sky/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-camp-forest">
-                              {item.sku}
-                            </span>
-                          </div>
-
-                          <div className="rounded-[18px] bg-camp-sand/25 px-3 py-2 text-sm text-slate-700 shadow-[inset_0_0_0_1px_rgba(12,58,42,0.03)]">
-                            <p className="text-[11px] uppercase tracking-[0.16em] text-camp-moss">
-                              Stock
-                            </p>
-                            <p className="mt-1 text-xl font-semibold text-camp-forest">
-                              {item.quantity}
-                            </p>
-                          </div>
-
-                          <div className="rounded-[18px] border border-camp-forest/10 bg-camp-sky/15 p-2">
-                            <StockMovementForm
-                              itemId={item.id}
-                              type="in"
-                              tone="primary"
-                              label="In"
-                            />
-                          </div>
-
-                          <div className="rounded-[18px] border border-camp-forest/10 bg-camp-sand/25 p-2">
-                            <StockMovementForm
-                              itemId={item.id}
-                              type="out"
-                              tone="secondary"
-                              label="Out"
-                            />
-                          </div>
-
-                          <DeleteItemButton itemId={item.id} itemName={item.name} sku={item.sku} />
-                        </div>
-                      </article>
-                    ))
+                    <StockSearchList items={stockItems} />
                   )}
                 </div>
               </InventorySectionCard>

--- a/app/inventory/stock-search-list.tsx
+++ b/app/inventory/stock-search-list.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { useDeferredValue, useState } from 'react';
+
+import {
+  filterInventoryStockItems,
+  type InventoryStockItem,
+  type InventoryStockSearchFilter,
+} from '@/lib/inventory/inventory-utils';
+
+import { DeleteItemButton } from './delete-item-button';
+import { StockMovementForm } from './stock-movement-form';
+
+type StockSearchListProps = {
+  items: InventoryStockItem[];
+};
+
+const filterOptions: { value: InventoryStockSearchFilter; label: string }[] = [
+  { value: 'name', label: 'Name' },
+  { value: 'sku', label: 'SKU' },
+];
+
+export function StockSearchList({ items }: StockSearchListProps) {
+  const [query, setQuery] = useState('');
+  const [filter, setFilter] = useState<InventoryStockSearchFilter>('name');
+  const deferredQuery = useDeferredValue(query);
+  const filteredItems = filterInventoryStockItems(items, deferredQuery, filter);
+
+  return (
+    <div className="grid gap-4">
+      <section className="rounded-[24px] border border-camp-forest/10 bg-white p-3 shadow-[inset_0_0_0_1px_rgba(12,58,42,0.02)]">
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto] lg:items-center">
+          <label className="relative block">
+            <span className="sr-only">Search stock by {filter}</span>
+            <svg
+              aria-hidden="true"
+              className="pointer-events-none absolute left-4 top-1/2 size-4 -translate-y-1/2 text-camp-moss"
+              fill="none"
+              stroke="currentColor"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth="1.8"
+              viewBox="0 0 24 24"
+            >
+              <path d="m21 21-4.3-4.3" />
+              <circle cx="11" cy="11" r="7" />
+            </svg>
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => {
+                setQuery(event.target.value);
+              }}
+              placeholder={`Search by ${filter === 'sku' ? 'SKU' : 'name'}`}
+              className="h-12 w-full rounded-full border border-camp-forest/10 bg-camp-sky/10 pl-11 pr-4 text-sm text-slate-900 outline-none transition placeholder:text-slate-400 focus:border-camp-moss/40 focus:bg-white focus:ring-2 focus:ring-camp-sky/60"
+            />
+          </label>
+
+          <div
+            aria-label="Choose stock search filter"
+            className="inline-grid grid-cols-2 rounded-full border border-camp-forest/10 bg-camp-sand/25 p-1"
+            role="group"
+          >
+            {filterOptions.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                aria-pressed={filter === option.value}
+                onClick={() => {
+                  setFilter(option.value);
+                }}
+                className={`rounded-full px-4 py-2 text-xs font-semibold uppercase tracking-[0.18em] transition ${
+                  filter === option.value
+                    ? 'bg-camp-forest text-white shadow-sm'
+                    : 'text-camp-moss hover:bg-white/70 hover:text-camp-forest'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <p className="mt-3 px-2 text-xs text-slate-500" aria-live="polite">
+          Showing {filteredItems.length} of {items.length} stock items.
+        </p>
+      </section>
+
+      {filteredItems.length === 0 ? (
+        <div className="rounded-[22px] border border-dashed border-camp-forest/20 bg-white/75 p-5 text-sm text-slate-600">
+          No stock items match this {filter} search.
+        </div>
+      ) : (
+        filteredItems.map((item) => (
+          <article
+            key={item.id}
+            className="rounded-[24px] border border-camp-forest/10 bg-white p-4"
+          >
+            <div className="grid gap-3 xl:grid-cols-[minmax(120px,1fr)_112px_minmax(205px,1fr)_minmax(215px,1fr)_40px] xl:items-center">
+              <div className="min-w-0">
+                <p className="truncate text-lg font-semibold text-camp-forest">{item.name}</p>
+                <span className="mt-1 inline-flex rounded-full bg-camp-sky/60 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-camp-forest">
+                  {item.sku}
+                </span>
+              </div>
+
+              <div className="rounded-[18px] bg-camp-sand/25 px-3 py-2 text-sm text-slate-700 shadow-[inset_0_0_0_1px_rgba(12,58,42,0.03)]">
+                <p className="text-[11px] uppercase tracking-[0.16em] text-camp-moss">Stock</p>
+                <p className="mt-1 text-xl font-semibold text-camp-forest">{item.quantity}</p>
+              </div>
+
+              <div className="rounded-[18px] border border-camp-forest/10 bg-camp-sky/15 p-2">
+                <StockMovementForm itemId={item.id} type="in" tone="primary" label="In" />
+              </div>
+
+              <div className="rounded-[18px] border border-camp-forest/10 bg-camp-sand/25 p-2">
+                <StockMovementForm itemId={item.id} type="out" tone="secondary" label="Out" />
+              </div>
+
+              <DeleteItemButton itemId={item.id} itemName={item.name} sku={item.sku} />
+            </div>
+          </article>
+        ))
+      )}
+    </div>
+  );
+}

--- a/lib/inventory/inventory-utils.ts
+++ b/lib/inventory/inventory-utils.ts
@@ -40,6 +40,8 @@ export type InventoryStockItem = {
   quantity: number;
 };
 
+export type InventoryStockSearchFilter = 'name' | 'sku';
+
 export type InventoryStatusMessage = {
   tone: 'success' | 'error';
   text: string;
@@ -131,6 +133,20 @@ export function buildInventoryStockItems(input: {
     .sort(
       (left, right) => left.name.localeCompare(right.name) || left.sku.localeCompare(right.sku)
     );
+}
+
+export function filterInventoryStockItems(
+  items: InventoryStockItem[],
+  query: string,
+  filter: InventoryStockSearchFilter
+) {
+  const normalizedQuery = query.trim().toLowerCase();
+
+  if (!normalizedQuery) {
+    return items;
+  }
+
+  return items.filter((item) => item[filter].toLowerCase().includes(normalizedQuery));
 }
 
 export function getInventoryStatusMessage(

--- a/lib/inventory/inventory-utils.ts
+++ b/lib/inventory/inventory-utils.ts
@@ -15,7 +15,9 @@ export type InventoryStockRecord = {
 
 export type InventoryMovementRecord = {
   id: string;
-  item_id: string;
+  item_id: string | null;
+  item_name: string | null;
+  item_sku: string | null;
   type: string;
   quantity: number | string | null;
   operator_name: string;
@@ -162,6 +164,11 @@ export function getInventoryStatusMessage(
       return {
         tone: 'success',
         text: 'Item deleted successfully.',
+      };
+    case 'history-cleared':
+      return {
+        tone: 'success',
+        text: 'Inventory history cleared successfully.',
       };
     case 'stock-in':
       return {

--- a/supabase/migrations/202604100001_inventory_mvp_reset.sql
+++ b/supabase/migrations/202604100001_inventory_mvp_reset.sql
@@ -32,9 +32,11 @@ create table if not exists public.inventory_stock (
 
 create table if not exists public.inventory_movements (
   id uuid primary key default gen_random_uuid(),
-  item_id uuid not null references public.inventory_items(id) on delete cascade,
-  type text not null check (type in ('in', 'out')),
-  quantity integer not null check (quantity > 0),
+  item_id uuid references public.inventory_items(id) on delete set null,
+  item_name text,
+  item_sku text,
+  type text not null check (type in ('in', 'out', 'delete')),
+  quantity integer not null check (quantity >= 0),
   operator_name text not null,
   time timestamptz not null default timezone('utc', now())
 );

--- a/supabase/migrations/202604110001_inventory_delete_history.sql
+++ b/supabase/migrations/202604110001_inventory_delete_history.sql
@@ -1,0 +1,31 @@
+alter table public.inventory_movements
+add column if not exists item_name text;
+
+alter table public.inventory_movements
+add column if not exists item_sku text;
+
+alter table public.inventory_movements
+drop constraint if exists inventory_movements_type_check;
+
+alter table public.inventory_movements
+add constraint inventory_movements_type_check
+check (type in ('in', 'out', 'delete'));
+
+alter table public.inventory_movements
+drop constraint if exists inventory_movements_quantity_check;
+
+alter table public.inventory_movements
+add constraint inventory_movements_quantity_check
+check (quantity >= 0);
+
+alter table public.inventory_movements
+drop constraint if exists inventory_movements_item_id_fkey;
+
+alter table public.inventory_movements
+alter column item_id drop not null;
+
+alter table public.inventory_movements
+add constraint inventory_movements_item_id_fkey
+foreign key (item_id)
+references public.inventory_items(id)
+on delete set null;

--- a/tests/inventory-utils.test.ts
+++ b/tests/inventory-utils.test.ts
@@ -110,6 +110,11 @@ describe('inventory utils', () => {
       text: 'Not enough stock for this outbound movement.',
     });
 
+    expect(getInventoryStatusMessage('history-cleared')).toEqual({
+      tone: 'success',
+      text: 'Inventory history cleared successfully.',
+    });
+
     expect(getInventoryStatusMessage(undefined)).toBeNull();
   });
 });

--- a/tests/inventory-utils.test.ts
+++ b/tests/inventory-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildInventoryStockItems,
+  filterInventoryStockItems,
   getInventoryStatusMessage,
   normalizeInventoryItemInput,
   normalizeInventoryMovementInput,
@@ -85,6 +86,17 @@ describe('inventory utils', () => {
         quantity: 4,
       },
     ]);
+  });
+
+  it('filters stock rows by name or sku', () => {
+    const items = [
+      { id: 'item-1', name: 'Bottled Water', sku: 'WATER-001', quantity: 12 },
+      { id: 'item-2', name: 'Walkie Talkie', sku: 'RADIO-001', quantity: 4 },
+    ];
+
+    expect(filterInventoryStockItems(items, 'water', 'name')).toEqual([items[0]]);
+    expect(filterInventoryStockItems(items, 'radio', 'sku')).toEqual([items[1]]);
+    expect(filterInventoryStockItems(items, ' ', 'sku')).toEqual(items);
   });
 
   it('maps inventory status codes to user-facing messages', () => {


### PR DESCRIPTION
## Summary
- add a Stock section search bar that filters inventory rows client-side
- add Name/SKU toggle controls for choosing the search field
- cover the stock filtering utility with tests

## Verification
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build
- screenshot pipeline: INVENTORY_SCREENSHOT_EMAIL=... INVENTORY_SCREENSHOT_PASSWORD=... INVENTORY_SCREENSHOT_PATH=artifacts/screenshots/inventory-stock-search.png pnpm screenshot:inventory
- Playwright smoke test for SKU toggle and empty search state