### PR TITLE
[codex] Fix inventory delete failure state

### DIFF
--- a/app/inventory/actions.ts
+++ b/app/inventory/actions.ts
@@ -6,6 +6,7 @@ import { redirect } from 'next/navigation';
 import { staffPrivilegedRoles } from '@/lib/app-config';
 import { getSession } from '@/lib/auth/session';
 import {
+  isInventoryDeleteHistoryCompatibilityError,
   isMissingInventoryMovementSnapshotColumnError,
   normalizeInventoryItemInput,
   normalizeInventoryMovementInput,
@@ -237,14 +238,31 @@ export async function deleteInventoryItem(
       throw error;
     }
 
-    await insertInventoryMovement(supabase, {
-      item_id: null,
-      item_name: item.name,
-      item_sku: item.sku,
-      type: 'delete',
-      quantity: stockRow?.quantity ?? 0,
-      operator_name: operatorName,
-    });
+    try {
+      await insertInventoryMovement(supabase, {
+        item_id: null,
+        item_name: item.name,
+        item_sku: item.sku,
+        type: 'delete',
+        quantity: stockRow?.quantity ?? 0,
+        operator_name: operatorName,
+      });
+    } catch (movementError) {
+      if (!isInventoryDeleteHistoryCompatibilityError(movementError)) {
+        throw movementError;
+      }
+
+      logServerError({
+        scope: 'inventory.delete_item_history',
+        message: 'Inventory item was deleted, but delete history could not be recorded',
+        error: movementError,
+        context: {
+          itemId,
+          itemName: item.name,
+          sku: item.sku,
+        },
+      });
+    }
 
     revalidatePath('/inventory');
     revalidatePath('/inventory/history');

--- a/lib/inventory/inventory-utils.ts
+++ b/lib/inventory/inventory-utils.ts
@@ -71,6 +71,29 @@ export function isMissingInventoryMovementSnapshotColumnError(error: unknown) {
   return (code === 'PGRST204' || code === '42703') && isInventoryMovementSnapshotColumn;
 }
 
+export function isInventoryDeleteHistoryCompatibilityError(error: unknown) {
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error && typeof error.code === 'string'
+      ? error.code
+      : '';
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' &&
+          error !== null &&
+          'message' in error &&
+          typeof error.message === 'string'
+        ? error.message
+        : '';
+
+  return (
+    (code === '23502' || code === '23514') &&
+    (message.includes('inventory_movements') ||
+      message.includes('inventory_movements_type_check') ||
+      message.includes('inventory_movements_item_id'))
+  );
+}
+
 function normalizeText(value: string | undefined) {
   const normalized = value?.trim() ?? '';
   return normalized.length > 0 ? normalized : null;

--- a/tests/e2e/inventory.spec.ts
+++ b/tests/e2e/inventory.spec.ts
@@ -114,6 +114,25 @@ test.describe.serial('inventory e2e', () => {
     await expect(page.getByText('Inventory action failed. Please try again.')).toHaveCount(0);
   });
 
+  test('deletes an item without showing the generic failure message', async ({ page }) => {
+    const skuPrefix = `PW-E2E-${Date.now()}-`;
+    const sku = `${skuPrefix}DELETE`;
+    const itemName = `Playwright Delete ${Date.now()}`;
+    skuPrefixes.add(skuPrefix);
+
+    await createInventoryItem(page, { name: itemName, sku });
+
+    const card = itemCard(page, itemName);
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain(itemName);
+      await dialog.accept();
+    });
+
+    await card.getByRole('button', { name: 'Delete item' }).click();
+    await expect(page.getByText(itemName, { exact: true })).toHaveCount(0);
+    await expect(page.getByText('Inventory action failed. Please try again.')).toHaveCount(0);
+  });
+
   test('shows stock movements in inventory history', async ({ page }) => {
     const skuPrefix = `PW-E2E-${Date.now()}-`;
     const sku = `${skuPrefix}HISTORY`;

--- a/tests/inventory-utils.test.ts
+++ b/tests/inventory-utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildInventoryStockItems,
   filterInventoryStockItems,
   getInventoryStatusMessage,
+  isInventoryDeleteHistoryCompatibilityError,
   isMissingInventoryMovementSnapshotColumnError,
   normalizeInventoryItemInput,
   normalizeInventoryMovementInput,
@@ -139,6 +140,31 @@ describe('inventory utils', () => {
       isMissingInventoryMovementSnapshotColumnError({
         code: 'PGRST204',
         message: "Could not find the 'name' column of 'inventory_items' in the schema cache",
+      })
+    ).toBe(false);
+  });
+
+  it('detects delete history compatibility errors', () => {
+    expect(
+      isInventoryDeleteHistoryCompatibilityError({
+        code: '23514',
+        message:
+          'new row for relation "inventory_movements" violates check constraint "inventory_movements_type_check"',
+      })
+    ).toBe(true);
+
+    expect(
+      isInventoryDeleteHistoryCompatibilityError({
+        code: '23502',
+        message:
+          'null value in column "item_id" of relation "inventory_movements" violates not-null constraint',
+      })
+    ).toBe(true);
+
+    expect(
+      isInventoryDeleteHistoryCompatibilityError({
+        code: '23514',
+        message: 'new row for relation "tasks" violates check constraint "tasks_status_check"',
       })
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Treat compatible delete-history logging failures as best-effort after the inventory item itself has already been deleted
- Add unit coverage for older inventory movement schema compatibility errors
- Add Playwright e2e coverage for deleting an inventory item without showing the generic failure banner

## Root Cause
On older Supabase schemas, the item deletion succeeds first, but recording a `delete` movement can fail because `inventory_movements.item_id` is still non-nullable or `delete` is not accepted by the movement type constraint. That post-delete history failure caused the UI to show `Inventory action failed. Please try again.` even though the item was gone.

## Validation
- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s vitest run tests/inventory-utils.test.ts`
- `pnpm test:e2e`
