### PR TITLE
[codex] Isolate e2e tests from production data

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,16 @@
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# Runtime app environment. Use production values for production deploys.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
+
+# Playwright e2e environment. Use a separate Supabase test project.
+E2E_SUPABASE_URL=
+E2E_SUPABASE_ANON_KEY=
+E2E_SUPABASE_SERVICE_ROLE_KEY=
+
+# Supabase migration targets.
 SUPABASE_ACCESS_TOKEN=
 SUPABASE_PROJECT_ID=
+SUPABASE_TEST_PROJECT_ID=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,9 @@ jobs:
 
       - name: End-to-end tests
         env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
+          E2E_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
+          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
         run: pnpm test:e2e
 
       - name: Build

--- a/.github/workflows/supabase-db.yml
+++ b/.github/workflows/supabase-db.yml
@@ -49,7 +49,14 @@ jobs:
         with:
           version: latest
 
-      - name: Push migrations to hosted project
+      - name: Push migrations to hosted test project
+        if: secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_TEST_PROJECT_ID != ''
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_ID: ${{ secrets.SUPABASE_TEST_PROJECT_ID }}
+        run: supabase db push --project-ref "$SUPABASE_PROJECT_ID"
+
+      - name: Push migrations to hosted production project
         if: secrets.SUPABASE_ACCESS_TOKEN != '' && secrets.SUPABASE_PROJECT_ID != ''
         env:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}

--- a/app/dev-tools/users/actions.ts
+++ b/app/dev-tools/users/actions.ts
@@ -1,0 +1,120 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { normalizeRoleActionInput } from '@/lib/dev-tools/user-directory';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+
+export type ChangeUserRoleState = {
+  status: 'idle' | 'success' | 'error';
+  message: string | null;
+  role: string | null;
+  submittedAt: number | null;
+};
+
+export async function changeUserRole(
+  _previousState: ChangeUserRoleState,
+  formData: FormData
+): Promise<ChangeUserRoleState> {
+  const userId = String(formData.get('userId') ?? '');
+  const targetRole = normalizeRoleActionInput(String(formData.get('role') ?? 'participant'));
+  const currentUserId = String(formData.get('currentUserId') ?? '');
+
+  const supabase = createSupabaseAdminClient();
+
+  if (!supabase) {
+    return {
+      status: 'error',
+      message: 'This environment needs the Supabase service role key for admin actions.',
+      role: null,
+      submittedAt: Date.now(),
+    };
+  }
+
+  const { data: authUserData, error: authUserError } =
+    await supabase.auth.admin.getUserById(userId);
+
+  if (authUserError || !authUserData.user) {
+    return {
+      status: 'error',
+      message: 'The role change could not be completed.',
+      role: null,
+      submittedAt: Date.now(),
+    };
+  }
+
+  const user = authUserData.user;
+  const { error: authUpdateError } = await supabase.auth.admin.updateUserById(userId, {
+    app_metadata: {
+      ...(user.app_metadata ?? {}),
+      role: targetRole,
+    },
+    user_metadata: {
+      ...(user.user_metadata ?? {}),
+      role: targetRole,
+    },
+  });
+
+  if (authUpdateError) {
+    return {
+      status: 'error',
+      message: 'The role change could not be completed.',
+      role: null,
+      submittedAt: Date.now(),
+    };
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('id')
+    .eq('auth_user_id', userId)
+    .maybeSingle<{ id: string }>();
+
+  if (profile?.id) {
+    try {
+      const { data: roleRecord, error: roleError } = await supabase
+        .from('roles')
+        .select('id')
+        .eq('name', targetRole)
+        .single<{ id: string }>();
+
+      if (roleError || !roleRecord) {
+        throw roleError ?? new Error('Role record unavailable');
+      }
+
+      const { error: deleteRolesError } = await supabase
+        .from('user_roles')
+        .delete()
+        .eq('user_id', profile.id);
+
+      if (deleteRolesError) {
+        throw deleteRolesError;
+      }
+
+      const { error: insertRoleError } = await supabase.from('user_roles').insert({
+        user_id: profile.id,
+        role_id: roleRecord.id,
+      });
+
+      if (insertRoleError) {
+        throw insertRoleError;
+      }
+    } catch {
+      // Auth metadata is the source of truth for app permissions. Some environments do not seed
+      // the legacy profile role tables, so this linkage sync is intentionally best effort.
+    }
+  }
+
+  revalidatePath('/dev-tools/users');
+  revalidatePath('/profile');
+
+  return {
+    status: 'success',
+    message:
+      userId === currentUserId
+        ? 'User role updated successfully. Reload the app if your own navigation should change immediately.'
+        : 'User role updated successfully.',
+    role: targetRole,
+    submittedAt: Date.now(),
+  };
+}

--- a/app/dev-tools/users/page.tsx
+++ b/app/dev-tools/users/page.tsx
@@ -3,16 +3,13 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 
 import { AppShell } from '@/components/layout/app-shell';
-import { appRoles } from '@/lib/app-config';
-import {
-  buildDirectoryEntries,
-  normalizePasswordResetInput,
-  normalizeRoleActionInput,
-} from '@/lib/dev-tools/user-directory';
+import { buildDirectoryEntries, normalizePasswordResetInput } from '@/lib/dev-tools/user-directory';
 import { getSession } from '@/lib/auth/session';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { hasSupabaseAdminEnv } from '@/lib/supabase/env';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+import { RoleChangeForm } from './role-change-form';
 
 async function loadDirectoryEntries() {
   if (!hasSupabaseAdminEnv()) {
@@ -60,90 +57,6 @@ async function loadCurrentAuthUserId() {
   } = await supabase.auth.getUser();
 
   return user?.id ?? null;
-}
-
-async function changeUserRole(formData: FormData) {
-  'use server';
-
-  const userId = String(formData.get('userId') ?? '');
-  const targetRole = normalizeRoleActionInput(String(formData.get('role') ?? 'participant'));
-  const currentUserId = String(formData.get('currentUserId') ?? '');
-
-  const supabase = createSupabaseAdminClient();
-
-  if (!supabase) {
-    redirect('/dev-tools/users?directory=unavailable');
-  }
-
-  const { data: authUserData, error: authUserError } =
-    await supabase.auth.admin.getUserById(userId);
-
-  if (authUserError || !authUserData.user) {
-    redirect('/dev-tools/users?directory=role-error');
-  }
-
-  const user = authUserData.user;
-  const { error: authUpdateError } = await supabase.auth.admin.updateUserById(userId, {
-    app_metadata: {
-      ...(user.app_metadata ?? {}),
-      role: targetRole,
-    },
-    user_metadata: {
-      ...(user.user_metadata ?? {}),
-      role: targetRole,
-    },
-  });
-
-  if (authUpdateError) {
-    redirect('/dev-tools/users?directory=role-error');
-  }
-
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('id')
-    .eq('auth_user_id', userId)
-    .maybeSingle<{ id: string }>();
-
-  if (profile?.id) {
-    try {
-      const { data: roleRecord, error: roleError } = await supabase
-        .from('roles')
-        .select('id')
-        .eq('name', targetRole)
-        .single<{ id: string }>();
-
-      if (roleError || !roleRecord) {
-        throw roleError ?? new Error('Role record unavailable');
-      }
-
-      const { error: deleteRolesError } = await supabase
-        .from('user_roles')
-        .delete()
-        .eq('user_id', profile.id);
-
-      if (deleteRolesError) {
-        throw deleteRolesError;
-      }
-
-      const { error: insertRoleError } = await supabase.from('user_roles').insert({
-        user_id: profile.id,
-        role_id: roleRecord.id,
-      });
-
-      if (insertRoleError) {
-        throw insertRoleError;
-      }
-    } catch {
-      // Auth metadata is the source of truth for app permissions. Some environments do not seed
-      // the legacy profile role tables, so this linkage sync is intentionally best effort.
-    }
-  }
-
-  revalidatePath('/dev-tools/users');
-  revalidatePath('/profile');
-  redirect(
-    `/dev-tools/users?directory=${userId === currentUserId ? 'current-role-updated' : 'role-updated'}`
-  );
 }
 
 async function resetUserPassword(formData: FormData) {
@@ -365,40 +278,11 @@ export default async function DevToolsUsersPage({
                       </td>
                       <td className="px-4 py-4 align-top">
                         <div className="min-w-56 space-y-4">
-                          <form action={changeUserRole} className="space-y-2">
-                            <input type="hidden" name="userId" value={entry.authUserId} />
-                            <input
-                              type="hidden"
-                              name="currentUserId"
-                              value={currentAuthUserId ?? ''}
-                            />
-                            <label
-                              htmlFor={`role-${entry.authUserId}`}
-                              className="block text-xs font-semibold uppercase tracking-[0.2em] text-camp-moss"
-                            >
-                              Change role
-                            </label>
-                            <div className="flex gap-2">
-                              <select
-                                id={`role-${entry.authUserId}`}
-                                name="role"
-                                defaultValue={entry.role.replace(' ', '_')}
-                                className="w-full rounded-xl border border-camp-forest/15 px-3 py-2 text-sm outline-none focus:border-camp-forest/40"
-                              >
-                                {appRoles.map((role) => (
-                                  <option key={role} value={role}>
-                                    {role.replace('_', ' ')}
-                                  </option>
-                                ))}
-                              </select>
-                              <button
-                                type="submit"
-                                className="rounded-xl bg-camp-forest px-3 py-2 text-sm font-semibold text-white transition hover:bg-camp-moss"
-                              >
-                                Save
-                              </button>
-                            </div>
-                          </form>
+                          <RoleChangeForm
+                            authUserId={entry.authUserId}
+                            currentAuthUserId={currentAuthUserId ?? ''}
+                            initialRole={entry.role}
+                          />
 
                           <form action={resetUserPassword} className="space-y-2">
                             <input type="hidden" name="userId" value={entry.authUserId} />

--- a/app/dev-tools/users/page.tsx
+++ b/app/dev-tools/users/page.tsx
@@ -105,32 +105,37 @@ async function changeUserRole(formData: FormData) {
     .maybeSingle<{ id: string }>();
 
   if (profile?.id) {
-    const { data: roleRecord, error: roleError } = await supabase
-      .from('roles')
-      .select('id')
-      .eq('name', targetRole)
-      .single<{ id: string }>();
+    try {
+      const { data: roleRecord, error: roleError } = await supabase
+        .from('roles')
+        .select('id')
+        .eq('name', targetRole)
+        .single<{ id: string }>();
 
-    if (roleError || !roleRecord) {
-      redirect('/dev-tools/users?directory=role-error');
-    }
+      if (roleError || !roleRecord) {
+        throw roleError ?? new Error('Role record unavailable');
+      }
 
-    const { error: deleteRolesError } = await supabase
-      .from('user_roles')
-      .delete()
-      .eq('user_id', profile.id);
+      const { error: deleteRolesError } = await supabase
+        .from('user_roles')
+        .delete()
+        .eq('user_id', profile.id);
 
-    if (deleteRolesError) {
-      redirect('/dev-tools/users?directory=role-error');
-    }
+      if (deleteRolesError) {
+        throw deleteRolesError;
+      }
 
-    const { error: insertRoleError } = await supabase.from('user_roles').insert({
-      user_id: profile.id,
-      role_id: roleRecord.id,
-    });
+      const { error: insertRoleError } = await supabase.from('user_roles').insert({
+        user_id: profile.id,
+        role_id: roleRecord.id,
+      });
 
-    if (insertRoleError) {
-      redirect('/dev-tools/users?directory=role-error');
+      if (insertRoleError) {
+        throw insertRoleError;
+      }
+    } catch {
+      // Auth metadata is the source of truth for app permissions. Some environments do not seed
+      // the legacy profile role tables, so this linkage sync is intentionally best effort.
     }
   }
 

--- a/app/dev-tools/users/role-change-form.tsx
+++ b/app/dev-tools/users/role-change-form.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { useActionState, useEffect, useState } from 'react';
+import { useFormStatus } from 'react-dom';
+
+import { appRoles } from '@/lib/app-config';
+
+import { changeUserRole, type ChangeUserRoleState } from './actions';
+
+const initialState: ChangeUserRoleState = {
+  status: 'idle',
+  message: null,
+  role: null,
+  submittedAt: null,
+};
+
+function SaveButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="rounded-xl bg-camp-forest px-3 py-2 text-sm font-semibold text-white transition hover:bg-camp-moss disabled:cursor-wait disabled:opacity-70"
+    >
+      {pending ? 'Saving...' : 'Save'}
+    </button>
+  );
+}
+
+export function RoleChangeForm({
+  authUserId,
+  currentAuthUserId,
+  initialRole,
+}: {
+  authUserId: string;
+  currentAuthUserId: string;
+  initialRole: string;
+}) {
+  const [selectedRole, setSelectedRole] = useState(initialRole.replace(' ', '_'));
+  const [state, formAction] = useActionState(changeUserRole, initialState);
+  const messageTone =
+    state.status === 'success'
+      ? 'border-emerald-200 bg-emerald-50/90 text-emerald-900'
+      : 'border-rose-200 bg-rose-50/90 text-rose-900';
+
+  useEffect(() => {
+    if (state.status === 'success' && state.role) {
+      setSelectedRole(state.role);
+    }
+  }, [state.role, state.status]);
+
+  return (
+    <form action={formAction} className="space-y-2">
+      <input type="hidden" name="userId" value={authUserId} />
+      <input type="hidden" name="currentUserId" value={currentAuthUserId} />
+      <label
+        htmlFor={`role-${authUserId}`}
+        className="block text-xs font-semibold uppercase tracking-[0.2em] text-camp-moss"
+      >
+        Change role
+      </label>
+      <div className="flex gap-2">
+        <select
+          id={`role-${authUserId}`}
+          name="role"
+          value={selectedRole}
+          onChange={(event) => {
+            setSelectedRole(event.target.value);
+          }}
+          className="w-full rounded-xl border border-camp-forest/15 px-3 py-2 text-sm outline-none focus:border-camp-forest/40"
+        >
+          {appRoles.map((role) => (
+            <option key={role} value={role}>
+              {role.replace('_', ' ')}
+            </option>
+          ))}
+        </select>
+        <SaveButton />
+      </div>
+      {state.message ? (
+        <p className={`rounded-xl border px-3 py-2 text-xs ${messageTone}`} aria-live="polite">
+          {state.message}
+        </p>
+      ) : null}
+    </form>
+  );
+}

--- a/docs/environment-strategy.md
+++ b/docs/environment-strategy.md
@@ -1,0 +1,53 @@
+# Environment Strategy
+
+## Supabase Projects
+
+Use separate Supabase projects for production data and e2e test data.
+
+- Production app runtime uses `NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY`.
+- Playwright e2e tests use `E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, and `E2E_SUPABASE_SERVICE_ROLE_KEY`.
+- E2E tests intentionally ignore the production Supabase variables. If the `E2E_SUPABASE_*` values are absent, the browser tests skip instead of running against production.
+
+## GitHub Actions Secrets
+
+Configure these repository secrets for the normal app and production migration path:
+
+- `NEXT_PUBLIC_SUPABASE_URL`
+- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+- `SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_ACCESS_TOKEN`
+- `SUPABASE_PROJECT_ID`
+
+Configure these repository secrets for e2e test isolation:
+
+- `E2E_SUPABASE_URL`
+- `E2E_SUPABASE_ANON_KEY`
+- `E2E_SUPABASE_SERVICE_ROLE_KEY`
+- `SUPABASE_TEST_PROJECT_ID`
+
+## Migration Flow
+
+The `Supabase DB` workflow validates migrations for pull requests. On `main`, it can push migrations to both hosted projects:
+
+- `SUPABASE_TEST_PROJECT_ID` keeps the e2e test project schema aligned.
+- `SUPABASE_PROJECT_ID` keeps the production project schema aligned.
+
+Both hosted projects should receive the same migration files. Seed data can differ, but required reference rows such as roles should exist in both projects when a feature depends on them.
+
+## Local E2E Setup
+
+For local e2e runs, create `.env.e2e.local` with test-project credentials:
+
+```env
+E2E_SUPABASE_URL=
+E2E_SUPABASE_ANON_KEY=
+E2E_SUPABASE_SERVICE_ROLE_KEY=
+```
+
+Run the suite with:
+
+```bash
+pnpm test:e2e
+```
+
+During Playwright runs, `playwright.config.ts` maps the `E2E_SUPABASE_*` values into the app server's runtime Supabase variables. This makes the browser, Next.js server actions, and Supabase admin cleanup all point at the test project for e2e only.

--- a/docs/product-scope.md
+++ b/docs/product-scope.md
@@ -4,7 +4,7 @@
 
 - Public landing page and sign-in entrypoint
 - Protected app shell for dashboard, events, tasks, check-in, profile, and admin areas
-- Supabase-ready environment strategy
+- Supabase-ready environment strategy with separate production and e2e test projects
 - Initial schema for profiles, roles, events, tasks, check-ins, and future chat
 - CI workflow for lint, typecheck, test, and build
 - PWA metadata and install icons

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,50 @@
 import { defineConfig, devices } from '@playwright/test';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 
 const port = Number(process.env.PORT ?? 3000);
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+function loadEnvFile(filePath: string) {
+  if (!existsSync(filePath)) {
+    return;
+  }
+
+  for (const line of readFileSync(filePath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue;
+    }
+
+    const separatorIndex = trimmed.indexOf('=');
+
+    if (separatorIndex === -1) {
+      continue;
+    }
+
+    const key = trimmed.slice(0, separatorIndex).trim();
+    const rawValue = trimmed.slice(separatorIndex + 1).trim();
+    const value = rawValue.replace(/^['"]|['"]$/g, '');
+
+    process.env[key] ??= value;
+  }
+}
+
+for (const fileName of ['.env.e2e.local', '.env.local', '.env']) {
+  loadEnvFile(path.resolve(process.cwd(), fileName));
+}
+
+if (
+  process.env.E2E_SUPABASE_URL &&
+  process.env.E2E_SUPABASE_ANON_KEY &&
+  process.env.E2E_SUPABASE_SERVICE_ROLE_KEY
+) {
+  process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.E2E_SUPABASE_URL;
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.E2E_SUPABASE_ANON_KEY;
+  process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.E2E_SUPABASE_SERVICE_ROLE_KEY;
+  process.env.NEXT_PUBLIC_APP_URL = baseURL;
+}
 
 export default defineConfig({
   testDir: './tests/e2e',

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -1,0 +1,111 @@
+import { expect, type Page, test } from '@playwright/test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { watchForBrowserErrors } from './helpers/browser-errors';
+import {
+  createE2ESupabaseAdminClient,
+  createE2EUser,
+  deleteE2EUser,
+  deleteE2EUsersByEmailPrefix,
+  hasSupabaseE2EEnv,
+} from './helpers/supabase';
+
+const hasE2EEnv = hasSupabaseE2EEnv();
+
+async function signIn(page: Page, user: { email: string; password: string }) {
+  await page.goto('/sign-in?redirectTo=/dashboard');
+  await page.getByLabel('Email address').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForFunction(() => window.location.pathname === '/dashboard');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe.serial('account e2e', () => {
+  test.skip(!hasE2EEnv, 'Supabase e2e environment variables are required');
+
+  let supabase: SupabaseClient;
+  const createdUserIds = new Set<string>();
+  const createdEmailPrefixes = new Set<string>();
+
+  test.beforeAll(() => {
+    supabase = createE2ESupabaseAdminClient();
+  });
+
+  test.afterEach(async () => {
+    for (const emailPrefix of createdEmailPrefixes) {
+      await deleteE2EUsersByEmailPrefix(supabase, emailPrefix);
+      createdEmailPrefixes.delete(emailPrefix);
+    }
+
+    for (const userId of createdUserIds) {
+      await deleteE2EUser(supabase, userId);
+      createdUserIds.delete(userId);
+    }
+  });
+
+  test('creates an account and lands on the profile page without browser errors', async ({
+    page,
+  }) => {
+    const browserErrors = watchForBrowserErrors(page);
+    const timestamp = Date.now();
+    const emailPrefix = `pw-account-${timestamp}`;
+    const email = `${emailPrefix}@example.com`;
+    const password = `PwAccount!${timestamp}Aa1`;
+    createdEmailPrefixes.add(emailPrefix);
+
+    await page.goto('/sign-up?redirectTo=/profile');
+    await page.getByLabel('First name').fill('Playwright');
+    await page.getByLabel('Last name').fill('Account');
+    await page.getByLabel('Preferred name').fill('PW Account');
+    await page.getByLabel('Email address').fill(email);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Create account' }).click();
+
+    await page.waitForFunction(() => window.location.pathname === '/profile');
+    const main = page.getByRole('main');
+    await expect(main.getByText('PW Account', { exact: true })).toBeVisible();
+    await expect(main.getByText(email, { exact: true })).toBeVisible();
+    await expect(main.getByText('participant', { exact: true })).toBeVisible();
+    await expect(page.getByText(/could not|failed|error/i)).toHaveCount(0);
+    browserErrors.expectNone();
+  });
+
+  test('changes the current account role without browser errors', async ({ page }) => {
+    const browserErrors = watchForBrowserErrors(page);
+    const user = await createE2EUser(supabase, {
+      role: 'super_admin',
+      emailPrefix: 'pw-role',
+      displayNamePrefix: 'PW Role',
+    });
+    createdUserIds.add(user.id);
+
+    await signIn(page, user);
+    await page.goto('/dev-tools/users');
+    await page.waitForLoadState('networkidle');
+
+    const currentUserRow = page
+      .getByText(user.email, { exact: true })
+      .locator('xpath=ancestor::tr[1]');
+    await expect(currentUserRow).toBeVisible();
+    await currentUserRow.getByLabel('Change role').selectOption('admin');
+    await currentUserRow.getByRole('button', { name: 'Save' }).click();
+
+    await page.waitForFunction(() =>
+      window.location.search.includes('directory=current-role-updated')
+    );
+    await expect(
+      page.getByText(
+        'User role updated successfully. Reload the app if your own navigation should change immediately.'
+      )
+    ).toBeVisible();
+    await expect(page.getByText('The role change could not be completed.')).toHaveCount(0);
+
+    await page.goto('/profile');
+    const main = page.getByRole('main');
+    await expect(main.getByText(user.email, { exact: true })).toBeVisible();
+    await expect(main.getByText('admin', { exact: true })).toBeVisible();
+    await expect(page.getByText(/could not|failed|error/i)).toHaveCount(0);
+    browserErrors.expectNone();
+  });
+});

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -89,16 +89,15 @@ test.describe.serial('account e2e', () => {
       .locator('xpath=ancestor::tr[1]');
     await expect(currentUserRow).toBeVisible();
     await currentUserRow.getByLabel('Change role').selectOption('admin');
+    await expect(page).toHaveURL(/\/dev-tools\/users$/);
     await currentUserRow.getByRole('button', { name: 'Save' }).click();
 
-    await page.waitForFunction(() =>
-      window.location.search.includes('directory=current-role-updated')
-    );
     await expect(
-      page.getByText(
+      currentUserRow.getByText(
         'User role updated successfully. Reload the app if your own navigation should change immediately.'
       )
     ).toBeVisible();
+    await expect(page).toHaveURL(/\/dev-tools\/users$/);
     await expect(page.getByText('The role change could not be completed.')).toHaveCount(0);
 
     await page.goto('/profile');

--- a/tests/e2e/helpers/browser-errors.ts
+++ b/tests/e2e/helpers/browser-errors.ts
@@ -1,0 +1,21 @@
+import { expect, type Page } from '@playwright/test';
+
+export function watchForBrowserErrors(page: Page) {
+  const errors: string[] = [];
+
+  page.on('pageerror', (error) => {
+    errors.push(error.message);
+  });
+
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+
+  return {
+    expectNone() {
+      expect(errors).toEqual([]);
+    },
+  };
+}

--- a/tests/e2e/helpers/supabase.ts
+++ b/tests/e2e/helpers/supabase.ts
@@ -11,7 +11,9 @@ type E2EUser = {
   displayName: string;
 };
 
-const envFiles = ['.env.local', '.env'];
+type E2ERole = 'super_admin' | 'admin' | 'staff' | 'participant';
+
+const envFiles = ['.env.e2e.local', '.env.local', '.env'];
 let envLoaded = false;
 
 function loadEnvFile(filePath: string) {
@@ -56,9 +58,9 @@ export function hasSupabaseE2EEnv() {
   loadE2EEnv();
 
   return Boolean(
-    process.env.NEXT_PUBLIC_SUPABASE_URL &&
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY &&
-    process.env.SUPABASE_SERVICE_ROLE_KEY
+    process.env.E2E_SUPABASE_URL &&
+    process.env.E2E_SUPABASE_ANON_KEY &&
+    process.env.E2E_SUPABASE_SERVICE_ROLE_KEY
   );
 }
 
@@ -69,34 +71,37 @@ export function createE2ESupabaseAdminClient() {
     throw new Error('Supabase e2e environment variables are missing');
   }
 
-  return createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE_KEY!,
-    {
-      auth: {
-        autoRefreshToken: false,
-        persistSession: false,
-      },
-    }
-  );
+  return createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
 }
 
-export async function createE2EStaffUser(supabase: SupabaseClient): Promise<E2EUser> {
+export async function createE2EUser(
+  supabase: SupabaseClient,
+  input: {
+    role: E2ERole;
+    emailPrefix?: string;
+    displayNamePrefix?: string;
+  }
+): Promise<E2EUser> {
   const runId = randomUUID().slice(0, 8);
-  const email = `codex-e2e-${runId}@example.com`;
+  const email = `${input.emailPrefix ?? 'codex-e2e'}-${runId}@example.com`;
   const password = `CodexE2E!${runId}Aa1`;
-  const displayName = `Codex E2E ${runId}`;
+  const displayName = `${input.displayNamePrefix ?? 'Codex E2E'} ${runId}`;
 
   const { data, error } = await supabase.auth.admin.createUser({
     email,
     password,
     email_confirm: true,
-    app_metadata: { role: 'staff' },
+    app_metadata: { role: input.role },
     user_metadata: { display_name: displayName },
   });
 
   if (error || !data.user) {
-    throw error ?? new Error('Could not create e2e staff user');
+    throw error ?? new Error('Could not create e2e user');
   }
 
   return {
@@ -105,6 +110,10 @@ export async function createE2EStaffUser(supabase: SupabaseClient): Promise<E2EU
     password,
     displayName,
   };
+}
+
+export async function createE2EStaffUser(supabase: SupabaseClient): Promise<E2EUser> {
+  return createE2EUser(supabase, { role: 'staff' });
 }
 
 export async function deleteE2EUser(supabase: SupabaseClient, userId: string | undefined) {
@@ -116,6 +125,20 @@ export async function deleteE2EUser(supabase: SupabaseClient, userId: string | u
 
   if (error) {
     throw error;
+  }
+}
+
+export async function deleteE2EUsersByEmailPrefix(supabase: SupabaseClient, emailPrefix: string) {
+  const { data, error } = await supabase.auth.admin.listUsers();
+
+  if (error) {
+    throw error;
+  }
+
+  const users = data.users.filter((user) => user.email?.startsWith(emailPrefix));
+
+  for (const user of users) {
+    await deleteE2EUser(supabase, user.id);
   }
 }
 


### PR DESCRIPTION
## Summary
- isolate Playwright e2e tests onto `E2E_SUPABASE_*` credentials so test entities cannot be created in production data
- add account creation and self-role-change e2e coverage with browser error assertions
- make Dev Tools role changes use inline action state instead of redirecting/reloading the whole page
- document production/test Supabase project setup and add a test-project migration target

## Environment setup
Production/runtime app secrets remain:
- `NEXT_PUBLIC_SUPABASE_URL`
- `NEXT_PUBLIC_SUPABASE_ANON_KEY`
- `SUPABASE_SERVICE_ROLE_KEY`
- `SUPABASE_ACCESS_TOKEN`
- `SUPABASE_PROJECT_ID`

E2E/test-only secrets are now:
- `E2E_SUPABASE_URL`
- `E2E_SUPABASE_ANON_KEY`
- `E2E_SUPABASE_SERVICE_ROLE_KEY`
- `SUPABASE_TEST_PROJECT_ID`

## Validation
- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s vitest run tests/inventory-utils.test.ts`
- `env -u E2E_SUPABASE_URL -u E2E_SUPABASE_ANON_KEY -u E2E_SUPABASE_SERVICE_ROLE_KEY pnpm test:e2e` → 6 skipped, confirming the suite no longer falls back to production Supabase credentials
