### PR TITLE
[codex] Fix dev tools role selection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The long-term product direction includes:
 
 ## Current phase
 
-We are currently entering Phase 2 (Tasks and check-in). Foundation and access layers are in place, and core task management is now fully operational.
+We are in Phase 2 (Tasks and check-in). The core operations foundation is now in place: auth, roles, events, registrations, inventory, tasks, admin/dev tooling, and CI-backed automated tests. The next product milestone is check-in.
 
 Completed so far:
 
@@ -36,13 +36,15 @@ Completed so far:
 - ✅ Database foundation with RLS and role-based permissions
 - ✅ Event browsing, registration, and admin management
 - ✅ Inventory tracking
+- ✅ Dev Tools user administration for account lookup, role changes, password resets, and test support
 - ✅ Task management — create, assign, reprioritize, transition, and close tasks (admin/staff)
+- ✅ Unit and e2e testing with isolated test data
 - ✅ CI/CD and deployment to Vercel
 
 Current priority:
 
 - Check-in workflows (code generation, manual and guided flows)
-- Remaining staff/admin operational controls
+- Smoothing remaining staff/admin operational controls
 
 ## Delivery roadmap
 
@@ -87,6 +89,9 @@ This phase adds the operational tools the team will use during real events:
 - ✅ Task reprioritization — low / medium / high / urgent
 - ✅ Status transitions — validated state machine with DB constraints and app-level guards
 - ✅ Admin & staff task management UI — list view with filters, detail view with inline editing
+- ✅ Inventory operations — add, remove, and audit stock actions with e2e coverage
+- ✅ Account operations — sign-up, profile landing, and role-change e2e coverage
+- ✅ Dev Tools user directory — admin account lookup, role changes, password reset, and removal support
 - Check-in code generation
 - Manual and guided check-in flows
 - Staff and admin operational controls (remaining items)
@@ -136,6 +141,19 @@ Useful contribution areas:
 
 When contributing, it helps to anchor work to one of the current phases so the repo keeps moving forward as a team instead of scattering into unrelated experiments.
 
+## Development and testing
+
+Common local commands:
+
+- `pnpm lint` — run ESLint and Prettier checks
+- `pnpm typecheck` — run TypeScript checks
+- `pnpm test` — run unit tests with Vitest
+- `pnpm test:e2e` — run Playwright browser tests
+
+E2E tests are intentionally isolated from production data. Local and CI browser tests use `E2E_SUPABASE_URL`, `E2E_SUPABASE_ANON_KEY`, and `E2E_SUPABASE_SERVICE_ROLE_KEY`; when those values are absent, Playwright skips the data-backed e2e suite rather than falling back to production Supabase credentials. See `docs/environment-strategy.md` for the current production/test environment setup.
+
+Role and permission changes should prefer client state updates and inline feedback over redirect-based status messages, especially in Dev Tools flows where the saved selection needs to stay visually in sync with the persisted role.
+
 ## Team working style
 
 We want the repo to feel collaborative, steady, and easy to join.
@@ -158,4 +176,4 @@ This project is on track when:
 
 ## Project snapshot
 
-We are building a camp and event operations app in phases. The foundation (auth, permissions, events, inventory) is complete. Task management for admins and staff is now fully operational — including create, assign, reprioritize, status transitions, and close. The next milestone is check-in workflows.
+We are building a camp and event operations app in phases. The foundation (auth, permissions, events, registrations, inventory, tasks, admin/dev account tooling, CI, and isolated e2e testing) is complete enough to support real workflow hardening. The next milestone is check-in workflows.

--- a/app/dev-tools/users/page.tsx
+++ b/app/dev-tools/users/page.tsx
@@ -250,7 +250,7 @@ export default async function DevToolsUsersPage({
                         </p>
                       </td>
                       <td className="px-4 py-4 align-top capitalize text-slate-700">
-                        {entry.role}
+                        {entry.role.replace('_', ' ')}
                       </td>
                       <td className="px-4 py-4 align-top">
                         <span

--- a/app/dev-tools/users/role-change-form.tsx
+++ b/app/dev-tools/users/role-change-form.tsx
@@ -3,7 +3,7 @@
 import { useActionState, useEffect, useState } from 'react';
 import { useFormStatus } from 'react-dom';
 
-import { appRoles } from '@/lib/app-config';
+import { appRoles, type AppRole } from '@/lib/app-config';
 
 import { changeUserRole, type ChangeUserRoleState } from './actions';
 
@@ -13,6 +13,10 @@ const initialState: ChangeUserRoleState = {
   role: null,
   submittedAt: null,
 };
+
+function normalizeSelectRole(value: string): AppRole {
+  return appRoles.includes(value as AppRole) ? (value as AppRole) : 'participant';
+}
 
 function SaveButton() {
   const { pending } = useFormStatus();
@@ -35,9 +39,9 @@ export function RoleChangeForm({
 }: {
   authUserId: string;
   currentAuthUserId: string;
-  initialRole: string;
+  initialRole: AppRole;
 }) {
-  const [selectedRole, setSelectedRole] = useState(initialRole.replace(' ', '_'));
+  const [selectedRole, setSelectedRole] = useState<AppRole>(initialRole);
   const [state, formAction] = useActionState(changeUserRole, initialState);
   const messageTone =
     state.status === 'success'
@@ -46,9 +50,13 @@ export function RoleChangeForm({
 
   useEffect(() => {
     if (state.status === 'success' && state.role) {
-      setSelectedRole(state.role);
+      setSelectedRole(normalizeSelectRole(state.role));
     }
   }, [state.role, state.status]);
+
+  useEffect(() => {
+    setSelectedRole(initialRole);
+  }, [initialRole]);
 
   return (
     <form action={formAction} className="space-y-2">
@@ -66,7 +74,7 @@ export function RoleChangeForm({
           name="role"
           value={selectedRole}
           onChange={(event) => {
-            setSelectedRole(event.target.value);
+            setSelectedRole(normalizeSelectRole(event.target.value));
           }}
           className="w-full rounded-xl border border-camp-forest/15 px-3 py-2 text-sm outline-none focus:border-camp-forest/40"
         >

--- a/lib/dev-tools/user-directory.ts
+++ b/lib/dev-tools/user-directory.ts
@@ -26,7 +26,7 @@ export type DirectoryEntry = {
   profileId?: string;
   email: string;
   displayName: string;
-  role: string;
+  role: AppRole;
   profileStatus: 'linked' | 'missing';
   createdAt?: string | null;
   lastSignInAt?: string | null;
@@ -70,7 +70,7 @@ export function buildDirectoryEntries(input: {
       }),
       role: normalizeRole(
         asOptionalString(user.app_metadata?.role) ?? asOptionalString(user.user_metadata?.role)
-      ).replace('_', ' '),
+      ),
       profileStatus: profile ? ('linked' as const) : ('missing' as const),
       createdAt: user.created_at ?? null,
       lastSignInAt: user.last_sign_in_at ?? null,

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -89,6 +89,7 @@ test.describe.serial('account e2e', () => {
       .locator('xpath=ancestor::tr[1]');
     await expect(currentUserRow).toBeVisible();
     await currentUserRow.getByLabel('Change role').selectOption('admin');
+    await expect(currentUserRow.getByLabel('Change role')).toHaveValue('admin');
     await expect(page).toHaveURL(/\/dev-tools\/users$/);
     await currentUserRow.getByRole('button', { name: 'Save' }).click();
 
@@ -98,6 +99,7 @@ test.describe.serial('account e2e', () => {
       )
     ).toBeVisible();
     await expect(page).toHaveURL(/\/dev-tools\/users$/);
+    await expect(currentUserRow.getByLabel('Change role')).toHaveValue('admin');
     await expect(page.getByText('The role change could not be completed.')).toHaveCount(0);
 
     await page.goto('/profile');

--- a/tests/user-directory.test.ts
+++ b/tests/user-directory.test.ts
@@ -72,7 +72,7 @@ describe('user directory', () => {
     ]);
   });
 
-  it('falls back to auth metadata for display name and formats super admin roles for the table', () => {
+  it('falls back to auth metadata for display name and keeps canonical role values', () => {
     expect(
       buildDirectoryEntries({
         authUsers: [
@@ -91,7 +91,7 @@ describe('user directory', () => {
         profileId: undefined,
         email: 'leader@example.com',
         displayName: 'Camp Lead',
-        role: 'super admin',
+        role: 'super_admin',
         profileStatus: 'missing',
         createdAt: null,
         lastSignInAt: null,


### PR DESCRIPTION
## Summary

- keep Dev Tools user roles in canonical `AppRole` form so the saved selection matches the persisted role
- resync the role select from server action state and refreshed server props without redirect-based status UX
- update the README to reflect the current project state, CI/e2e setup, and test/prod environment split

## Root cause

The user directory converted canonical roles like `super_admin` into display labels like `super admin` before passing them into the client role form. The form then tried to convert that display label back into a select value and could drift from the actual persisted role after server refreshes.

## Validation

- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s vitest run tests/user-directory.test.ts tests/inventory-utils.test.ts`
- `pnpm test:e2e` (6 skipped locally because `E2E_SUPABASE_*` secrets are not configured, which confirms no production fallback)
