### PR TITLE
[codex] Add dashboard weekly calendar

### DIFF
--- a/app/dashboard/calendar-actions.ts
+++ b/app/dashboard/calendar-actions.ts
@@ -1,0 +1,94 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { createSupabaseServerClient } from '@/lib/supabase/server';
+
+export type CreateCalendarEventInput = {
+  title: string;
+  startsAt: string;
+  endsAt: string;
+};
+
+export type CreateCalendarEventResult = {
+  status: 'success' | 'error';
+  message: string;
+};
+
+function normalizeCalendarEventInput(input: CreateCalendarEventInput) {
+  const title = input.title.trim();
+  const startsAt = new Date(input.startsAt);
+  const endsAt = new Date(input.endsAt);
+
+  if (!title) {
+    throw new Error('Add a title before creating the event.');
+  }
+
+  if (Number.isNaN(startsAt.getTime()) || Number.isNaN(endsAt.getTime())) {
+    throw new Error('Choose a valid time window.');
+  }
+
+  if (endsAt <= startsAt) {
+    throw new Error('The event must end after it starts.');
+  }
+
+  return {
+    title,
+    startsAt: startsAt.toISOString(),
+    endsAt: endsAt.toISOString(),
+  };
+}
+
+export async function createPersonalCalendarEvent(
+  input: CreateCalendarEventInput
+): Promise<CreateCalendarEventResult> {
+  try {
+    const supabase = await createSupabaseServerClient();
+
+    if (!supabase) {
+      throw new Error('Supabase is required to create calendar events.');
+    }
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      throw new Error('Sign in before creating a calendar event.');
+    }
+
+    const { data: profile, error: profileError } = await supabase
+      .from('profiles')
+      .select('id')
+      .eq('auth_user_id', user.id)
+      .single();
+
+    if (profileError || !profile) {
+      throw new Error('Your profile could not be found.');
+    }
+
+    const normalized = normalizeCalendarEventInput(input);
+    const { error } = await supabase.from('personal_calendar_events').insert({
+      owner_profile_id: profile.id,
+      title: normalized.title,
+      starts_at: normalized.startsAt,
+      ends_at: normalized.endsAt,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    revalidatePath('/dashboard');
+
+    return {
+      status: 'success',
+      message: 'Event added to your calendar.',
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      message: error instanceof Error ? error.message : 'The calendar event could not be created.',
+    };
+  }
+}

--- a/app/dashboard/dashboard-calendar.tsx
+++ b/app/dashboard/dashboard-calendar.tsx
@@ -1,0 +1,425 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { startTransition, useMemo, useState } from 'react';
+
+import { createPersonalCalendarEvent } from './calendar-actions';
+
+export type CalendarProfile = {
+  id: string;
+  displayName: string;
+  email: string;
+};
+
+export type CalendarItem = {
+  id: string;
+  title: string;
+  location?: string | null;
+  startsAt: string;
+  endsAt: string;
+  kind: 'event' | 'personal';
+  status?: string | null;
+  href?: string;
+};
+
+type Selection = {
+  dayIndex: number;
+  startSlot: number;
+  endSlot: number;
+};
+
+type DraftEvent = {
+  startsAt: Date;
+  endsAt: Date;
+};
+
+const dayFormatter = new Intl.DateTimeFormat('en-GB', { weekday: 'short' });
+const dateFormatter = new Intl.DateTimeFormat('en-GB', { day: 'numeric', month: 'short' });
+const timeFormatter = new Intl.DateTimeFormat('en-GB', {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+const dayCount = 7;
+const slotMinutes = 30;
+const startHour = 6;
+const endHour = 22;
+const slotsPerDay = ((endHour - startHour) * 60) / slotMinutes;
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function toDateInputValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function slotToDate(weekStart: Date, dayIndex: number, slotIndex: number) {
+  const date = addDays(weekStart, dayIndex);
+  date.setHours(startHour, slotIndex * slotMinutes, 0, 0);
+  return date;
+}
+
+function getItemLayout(item: CalendarItem, weekStart: Date) {
+  const startsAt = new Date(item.startsAt);
+  const endsAt = new Date(item.endsAt);
+  const dayIndex = Math.floor(
+    (new Date(startsAt.getFullYear(), startsAt.getMonth(), startsAt.getDate()).getTime() -
+      new Date(weekStart.getFullYear(), weekStart.getMonth(), weekStart.getDate()).getTime()) /
+      86_400_000
+  );
+
+  if (dayIndex < 0 || dayIndex >= dayCount) {
+    return null;
+  }
+
+  const startMinutes = startsAt.getHours() * 60 + startsAt.getMinutes();
+  const endMinutes = endsAt.getHours() * 60 + endsAt.getMinutes();
+  const top = Math.max(0, ((startMinutes - startHour * 60) / ((endHour - startHour) * 60)) * 100);
+  const height = Math.max(5, ((endMinutes - startMinutes) / ((endHour - startHour) * 60)) * 100);
+
+  return {
+    dayIndex,
+    top,
+    height: Math.min(height, 100 - top),
+  };
+}
+
+function buildDashboardHref(week: Date, profileId: string) {
+  return `/dashboard?week=${toDateInputValue(week)}&profile=${profileId}`;
+}
+
+export function DashboardCalendar({
+  currentProfileId,
+  selectedProfileId,
+  profiles,
+  items,
+  weekStart,
+}: {
+  currentProfileId: string;
+  selectedProfileId: string;
+  profiles: CalendarProfile[];
+  items: CalendarItem[];
+  weekStart: string;
+}) {
+  const router = useRouter();
+  const weekStartDate = useMemo(() => new Date(`${weekStart}T00:00:00`), [weekStart]);
+  const days = useMemo(
+    () => Array.from({ length: dayCount }, (_, index) => addDays(weekStartDate, index)),
+    [weekStartDate]
+  );
+  const [selection, setSelection] = useState<Selection | null>(null);
+  const [draftEvent, setDraftEvent] = useState<DraftEvent | null>(null);
+  const [draftTitle, setDraftTitle] = useState('Personal event');
+  const [dragging, setDragging] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+  const canEdit = selectedProfileId === currentProfileId;
+  const selectedProfile = profiles.find((profile) => profile.id === selectedProfileId);
+  const previousWeek = addDays(weekStartDate, -7);
+  const nextWeek = addDays(weekStartDate, 7);
+  const now = new Date();
+  const todayIndex = days.findIndex(
+    (day) =>
+      day.getFullYear() === now.getFullYear() &&
+      day.getMonth() === now.getMonth() &&
+      day.getDate() === now.getDate()
+  );
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const showNowLine = todayIndex >= 0 && nowMinutes >= startHour * 60 && nowMinutes <= endHour * 60;
+  const nowTop = ((nowMinutes - startHour * 60) / ((endHour - startHour) * 60)) * 100;
+
+  function beginSelection(dayIndex: number, slotIndex: number) {
+    if (!canEdit || pending) {
+      return;
+    }
+
+    setMessage(null);
+    setSelection({ dayIndex, startSlot: slotIndex, endSlot: slotIndex });
+    setDragging(true);
+  }
+
+  function extendSelection(dayIndex: number, slotIndex: number) {
+    if (!dragging || !selection || selection.dayIndex !== dayIndex) {
+      return;
+    }
+
+    setSelection({ ...selection, endSlot: slotIndex });
+  }
+
+  function finishSelection() {
+    if (!dragging || !selection) {
+      return;
+    }
+
+    setDragging(false);
+
+    const firstSlot = Math.min(selection.startSlot, selection.endSlot);
+    const lastSlot = Math.max(selection.startSlot, selection.endSlot);
+    const startsAt = slotToDate(weekStartDate, selection.dayIndex, firstSlot);
+    const endsAt = slotToDate(weekStartDate, selection.dayIndex, lastSlot + 1);
+    setSelection(null);
+    setDraftEvent({ startsAt, endsAt });
+    setDraftTitle('Personal event');
+  }
+
+  function createDraftEvent() {
+    if (!draftEvent) {
+      return;
+    }
+
+    setPending(true);
+    startTransition(async () => {
+      const result = await createPersonalCalendarEvent({
+        title: draftTitle,
+        startsAt: draftEvent.startsAt.toISOString(),
+        endsAt: draftEvent.endsAt.toISOString(),
+      });
+      setMessage(result.message);
+      setPending(false);
+
+      if (result.status === 'success') {
+        setDraftEvent(null);
+        router.refresh();
+      }
+    });
+  }
+
+  return (
+    <section className="rounded-[32px] border border-camp-forest/10 bg-white/90 p-5 shadow-panel backdrop-blur">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+        <div>
+          <p className="text-xs uppercase tracking-[0.28em] text-camp-moss">Weekly calendar</p>
+          <h2 className="mt-3 font-serif text-3xl text-camp-forest">
+            {selectedProfile?.displayName ?? 'Calendar'}
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm text-slate-600">
+            {canEdit
+              ? 'Tap or drag across a time window to add a personal event.'
+              : 'Viewing another user’s calendar. Event creation is disabled in this view.'}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <label className="text-sm font-semibold text-camp-forest">
+            <span className="sr-only">Calendar owner</span>
+            <select
+              value={selectedProfileId}
+              onChange={(event) => {
+                router.push(buildDashboardHref(weekStartDate, event.target.value));
+              }}
+              className="w-full rounded-2xl border border-camp-forest/10 bg-white px-4 py-3 text-sm outline-none transition focus:border-camp-moss focus:ring-2 focus:ring-camp-sky/70 sm:w-64"
+            >
+              {profiles.map((profile) => (
+                <option key={profile.id} value={profile.id}>
+                  {profile.displayName} {profile.id === currentProfileId ? '(me)' : ''}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <div className="grid grid-cols-2 gap-2">
+            <Link
+              href={buildDashboardHref(previousWeek, selectedProfileId)}
+              className="rounded-2xl border border-camp-forest/10 bg-camp-sand/45 px-4 py-3 text-center text-sm font-semibold text-camp-forest transition hover:bg-camp-sand"
+            >
+              ← Previous
+            </Link>
+            <Link
+              href={buildDashboardHref(nextWeek, selectedProfileId)}
+              className="rounded-2xl bg-camp-forest px-4 py-3 text-center text-sm font-semibold text-white transition hover:bg-camp-moss"
+            >
+              Next →
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {message ? (
+        <p className="mt-4 rounded-2xl border border-camp-forest/10 bg-camp-sky/55 px-4 py-3 text-sm text-camp-forest">
+          {message}
+        </p>
+      ) : null}
+
+      {draftEvent ? (
+        <form
+          action={createDraftEvent}
+          className="mt-4 rounded-[24px] border border-camp-forest/10 bg-camp-sky/35 p-4 shadow-sm"
+        >
+          <div className="grid gap-4 lg:grid-cols-[1fr_auto] lg:items-end">
+            <label className="text-sm font-semibold text-camp-forest">
+              Event title
+              <input
+                value={draftTitle}
+                onChange={(event) => setDraftTitle(event.target.value)}
+                className="mt-2 w-full rounded-2xl border border-camp-forest/10 bg-white px-4 py-3 text-sm font-normal text-slate-900 outline-none transition focus:border-camp-moss focus:ring-2 focus:ring-camp-sky"
+              />
+            </label>
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+              <p className="rounded-2xl bg-white/75 px-4 py-3 text-sm text-camp-forest">
+                {dateFormatter.format(draftEvent.startsAt)} ·{' '}
+                {timeFormatter.format(draftEvent.startsAt)}–
+                {timeFormatter.format(draftEvent.endsAt)}
+              </p>
+              <button
+                type="submit"
+                disabled={pending}
+                className="rounded-2xl bg-camp-forest px-5 py-3 text-sm font-semibold text-white transition hover:bg-camp-moss disabled:cursor-wait disabled:opacity-70"
+              >
+                {pending ? 'Creating...' : 'Create event'}
+              </button>
+              <button
+                type="button"
+                onClick={() => setDraftEvent(null)}
+                className="rounded-2xl border border-camp-forest/10 bg-white px-5 py-3 text-sm font-semibold text-camp-forest transition hover:bg-camp-sand/40"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </form>
+      ) : null}
+
+      <div className="mt-6 overflow-x-auto rounded-[28px] border border-camp-forest/10 bg-camp-sand/20">
+        <div className="min-w-[920px]">
+          <div className="grid grid-cols-[72px_repeat(7,minmax(120px,1fr))] border-b border-camp-forest/10 bg-white/80">
+            <div className="px-3 py-4 text-xs font-semibold uppercase tracking-[0.18em] text-camp-moss">
+              Time
+            </div>
+            {days.map((day) => (
+              <div key={day.toISOString()} className="border-l border-camp-forest/10 px-3 py-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.18em] text-camp-moss">
+                  {dayFormatter.format(day)}
+                </p>
+                <p className="mt-1 font-serif text-xl text-camp-forest">
+                  {dateFormatter.format(day)}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-[72px_repeat(7,minmax(120px,1fr))]">
+            <div
+              className="grid"
+              style={{ gridTemplateRows: `repeat(${endHour - startHour}, 72px)` }}
+            >
+              {Array.from({ length: endHour - startHour }, (_, index) => (
+                <div
+                  key={index}
+                  className="border-b border-camp-forest/10 bg-white/55 px-3 pt-2 text-xs text-slate-500"
+                >
+                  {String(startHour + index).padStart(2, '0')}:00
+                </div>
+              ))}
+            </div>
+
+            {days.map((day, dayIndex) => (
+              <div
+                key={day.toISOString()}
+                className="relative border-l border-camp-forest/10 bg-white/40"
+                style={{ height: `${(endHour - startHour) * 72}px` }}
+                onPointerLeave={() => {
+                  if (dragging) {
+                    setDragging(false);
+                  }
+                }}
+              >
+                <div
+                  className="absolute inset-0 grid"
+                  style={{ gridTemplateRows: `repeat(${slotsPerDay}, 36px)` }}
+                >
+                  {Array.from({ length: slotsPerDay }, (_, slotIndex) => {
+                    const isSelected =
+                      selection?.dayIndex === dayIndex &&
+                      slotIndex >= Math.min(selection.startSlot, selection.endSlot) &&
+                      slotIndex <= Math.max(selection.startSlot, selection.endSlot);
+
+                    return (
+                      <button
+                        key={slotIndex}
+                        type="button"
+                        disabled={!canEdit || pending}
+                        aria-label={`Create event on ${dateFormatter.format(day)} at ${timeFormatter.format(
+                          slotToDate(weekStartDate, dayIndex, slotIndex)
+                        )}`}
+                        className={`border-b border-camp-forest/5 transition ${
+                          canEdit ? 'cursor-crosshair hover:bg-camp-sky/40' : 'cursor-default'
+                        } ${isSelected ? 'bg-camp-sky/70' : ''}`}
+                        onPointerDown={() => beginSelection(dayIndex, slotIndex)}
+                        onPointerEnter={() => extendSelection(dayIndex, slotIndex)}
+                        onPointerUp={finishSelection}
+                      />
+                    );
+                  })}
+                </div>
+
+                {showNowLine && todayIndex === dayIndex ? (
+                  <div
+                    className="pointer-events-none absolute left-0 right-0 z-20 flex items-center"
+                    style={{ top: `${nowTop}%` }}
+                  >
+                    <span className="size-2 rounded-full bg-camp-ember shadow" />
+                    <span className="h-0.5 flex-1 bg-camp-ember shadow" />
+                    <span className="mr-2 rounded-full bg-camp-ember px-2 py-0.5 text-[10px] font-semibold text-white">
+                      Now
+                    </span>
+                  </div>
+                ) : null}
+
+                {items
+                  .map((item) => ({ item, layout: getItemLayout(item, weekStartDate) }))
+                  .filter((entry) => entry.layout?.dayIndex === dayIndex)
+                  .map(({ item, layout }) => {
+                    if (!layout) {
+                      return null;
+                    }
+
+                    const content = (
+                      <div
+                        className={`absolute left-2 right-2 z-10 overflow-hidden rounded-2xl border px-3 py-2 text-xs shadow-sm ${
+                          item.kind === 'event'
+                            ? 'border-camp-forest/15 bg-camp-forest text-white'
+                            : 'border-camp-moss/20 bg-camp-sky text-camp-forest'
+                        }`}
+                        style={{ top: `${layout.top}%`, height: `${layout.height}%` }}
+                      >
+                        <p className="font-semibold">{item.title}</p>
+                        <p className="mt-1 opacity-85">
+                          {timeFormatter.format(new Date(item.startsAt))}–
+                          {timeFormatter.format(new Date(item.endsAt))}
+                        </p>
+                        {item.location ? (
+                          <p className="mt-1 truncate opacity-80">{item.location}</p>
+                        ) : null}
+                      </div>
+                    );
+
+                    return item.href ? (
+                      <Link key={item.id} href={item.href}>
+                        {content}
+                      </Link>
+                    ) : (
+                      <div key={item.id}>{content}</div>
+                    );
+                  })}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="mt-5 rounded-[24px] border border-dashed border-camp-forest/20 bg-camp-sand/25 p-5 text-sm text-slate-600">
+          No events are scheduled in this week. Use the calendar grid to create one for yourself.
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,64 +1,222 @@
-import Link from 'next/link';
 import { AppShell } from '@/components/layout/app-shell';
 import { MetricCard } from '@/components/layout/metric-card';
+import { staffPrivilegedRoles } from '@/lib/app-config';
+import { getSession } from '@/lib/auth/session';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
-export default async function DashboardPage() {
+import { DashboardCalendar, type CalendarItem, type CalendarProfile } from './dashboard-calendar';
+
+type DashboardPageProps = {
+  searchParams: Promise<{
+    week?: string;
+    profile?: string;
+  }>;
+};
+
+type ProfileRow = {
+  id: string;
+  display_name: string | null;
+  email: string | null;
+};
+
+type RegistrationRow = {
+  id: string;
+  status: string | null;
+  events:
+    | {
+        id: string;
+        title: string;
+        slug: string;
+        location: string | null;
+        starts_at: string;
+        ends_at: string;
+      }
+    | {
+        id: string;
+        title: string;
+        slug: string;
+        location: string | null;
+        starts_at: string;
+        ends_at: string;
+      }[]
+    | null;
+};
+
+type PersonalEventRow = {
+  id: string;
+  title: string;
+  starts_at: string;
+  ends_at: string;
+};
+
+function getWeekStart(input?: string) {
+  const candidate = input ? new Date(`${input}T00:00:00`) : new Date();
+  const date = Number.isNaN(candidate.getTime()) ? new Date() : candidate;
+  const weekStart = new Date(date);
+  const day = weekStart.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  weekStart.setDate(weekStart.getDate() + diff);
+  weekStart.setHours(0, 0, 0, 0);
+  return weekStart;
+}
+
+function addDays(date: Date, days: number) {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  return next;
+}
+
+function toDateInputValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function mapProfile(row: ProfileRow): CalendarProfile {
+  return {
+    id: row.id,
+    displayName: row.display_name ?? row.email?.split('@')[0] ?? 'Camp user',
+    email: row.email ?? 'unknown@example.com',
+  };
+}
+
+function getJoinedEvent(row: RegistrationRow) {
+  return Array.isArray(row.events) ? row.events[0] : row.events;
+}
+
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const params = await searchParams;
+  const session = await getSession();
   const supabase = await createSupabaseServerClient();
-  if (!supabase) return null;
+
+  if (!supabase) {
+    return (
+      <AppShell title="Dashboard" eyebrow="Protected route">
+        <div className="rounded-[28px] border border-camp-forest/10 bg-white/85 p-6 text-sm text-slate-600 shadow-panel">
+          Connect Supabase to use the dashboard calendar.
+        </div>
+      </AppShell>
+    );
+  }
 
   const {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const { count: eventCount } = await supabase
-    .from('events')
-    .select('*', { count: 'exact', head: true });
+  const [{ count: eventCount }, { count: activeTaskCount }, { count: checkinCount }] =
+    await Promise.all([
+      supabase.from('events').select('*', { count: 'exact', head: true }),
+      supabase
+        .from('tasks')
+        .select('*', { count: 'exact', head: true })
+        .in('status', ['open', 'in_progress', 'blocked']),
+      supabase.from('checkins').select('*', { count: 'exact', head: true }),
+    ]);
 
-  const { count: activeTaskCount } = await supabase
-    .from('tasks')
-    .select('*', { count: 'exact', head: true })
-    .in('status', ['open', 'in_progress', 'blocked']);
+  let currentProfile: ProfileRow | null = null;
 
-  const { count: checkinCount } = await supabase
-    .from('checkins')
-    .select('*', { count: 'exact', head: true });
-
-  // Get user profile if authenticated
-  let registrations = null;
   if (user) {
-    const { data: profile } = await supabase
+    const { data } = await supabase
       .from('profiles')
-      .select('id')
+      .select('id, display_name, email')
       .eq('auth_user_id', user.id)
       .single();
+    currentProfile = data;
+  }
 
-    if (profile) {
-      const { data } = await supabase
+  const weekStart = getWeekStart(params.week);
+  const weekEnd = addDays(weekStart, 7);
+  const canInspectOthers = staffPrivilegedRoles.includes(session.role);
+  const adminSupabase = canInspectOthers ? createSupabaseAdminClient() : null;
+  const readClient = adminSupabase ?? supabase;
+  const { data: profileRows } = await readClient
+    .from('profiles')
+    .select('id, display_name, email')
+    .order('display_name', { ascending: true });
+  const profiles = (profileRows ?? []).map(mapProfile);
+  const profileIds = new Set(profiles.map((profile) => profile.id));
+  const selectedProfileId =
+    params.profile &&
+    profileIds.has(params.profile) &&
+    (canInspectOthers || params.profile === currentProfile?.id)
+      ? params.profile
+      : currentProfile?.id;
+
+  let calendarItems: CalendarItem[] = [];
+
+  if (selectedProfileId) {
+    const [registrationsResult, personalEventsResult] = await Promise.all([
+      readClient
         .from('event_registrations')
         .select(
           `
+          id,
           status,
-          registered_at,
-          events (
+          events!inner (
             id,
             title,
             slug,
             location,
-            starts_at
+            starts_at,
+            ends_at
           )
         `
         )
-        .eq('user_id', profile.id)
-        .order('registered_at', { ascending: false });
+        .eq('user_id', selectedProfileId)
+        .neq('status', 'cancelled')
+        .gte('events.starts_at', weekStart.toISOString())
+        .lt('events.starts_at', weekEnd.toISOString()),
+      readClient
+        .from('personal_calendar_events')
+        .select('id, title, starts_at, ends_at')
+        .eq('owner_profile_id', selectedProfileId)
+        .lt('starts_at', weekEnd.toISOString())
+        .gt('ends_at', weekStart.toISOString()),
+    ]);
 
-      registrations = data;
-    }
+    const registrationItems: CalendarItem[] = (
+      (registrationsResult.data ?? []) as RegistrationRow[]
+    ).flatMap((registration) => {
+      const event = getJoinedEvent(registration);
+
+      if (!event) {
+        return [];
+      }
+
+      return [
+        {
+          id: `registration-${registration.id}`,
+          title: event.title,
+          location: event.location,
+          startsAt: event.starts_at,
+          endsAt: event.ends_at,
+          kind: 'event' as const,
+          status: registration.status,
+          href: `/events/${event.slug}`,
+        },
+      ];
+    });
+
+    const personalItems = ((personalEventsResult.data ?? []) as PersonalEventRow[]).map(
+      (event) => ({
+        id: `personal-${event.id}`,
+        title: event.title,
+        startsAt: event.starts_at,
+        endsAt: event.ends_at,
+        kind: 'personal' as const,
+      })
+    );
+
+    calendarItems = [...registrationItems, ...personalItems].sort(
+      (first, second) => new Date(first.startsAt).getTime() - new Date(second.startsAt).getTime()
+    );
   }
 
   return (
     <AppShell title="Dashboard" eyebrow="Protected route">
-      <div className="mb-10 grid gap-5 md:grid-cols-3">
+      <div className="mb-6 grid gap-5 md:grid-cols-3">
         <MetricCard
           label="Open events"
           value={String(eventCount ?? 0)}
@@ -76,49 +234,18 @@ export default async function DashboardPage() {
         />
       </div>
 
-      {user && (
-        <section>
-          <h2 className="mb-4 font-serif text-xl text-camp-forest">My Registrations</h2>
-          <div className="grid gap-4">
-            {(registrations || []).length === 0 ? (
-              <p className="text-sm text-slate-500">
-                You haven&apos;t registered for any events yet.
-              </p>
-            ) : (
-              (registrations || []).map((reg: any, i: number) => (
-                <Link
-                  key={i}
-                  href={`/events/${reg.events.slug}`}
-                  className="block rounded-[24px] border border-camp-forest/10 bg-white/85 p-5 shadow-panel transition hover:border-camp-forest/25"
-                >
-                  <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <div>
-                      <h3 className="font-serif text-xl text-camp-forest">{reg.events.title}</h3>
-                      <p className="mt-1 text-sm text-slate-600">{reg.events.location}</p>
-                    </div>
-                    <div className="text-sm text-slate-600 md:text-right">
-                      <p>
-                        Status:{' '}
-                        <span
-                          className={`font-semibold capitalize ${
-                            reg.status === 'waitlisted'
-                              ? 'text-amber-600'
-                              : reg.status === 'registered'
-                                ? 'text-green-600'
-                                : 'text-slate-500'
-                          }`}
-                        >
-                          {reg.status}
-                        </span>
-                      </p>
-                      <p>Starts: {new Date(reg.events.starts_at).toLocaleString()}</p>
-                    </div>
-                  </div>
-                </Link>
-              ))
-            )}
-          </div>
-        </section>
+      {currentProfile && selectedProfileId ? (
+        <DashboardCalendar
+          currentProfileId={currentProfile.id}
+          selectedProfileId={selectedProfileId}
+          profiles={profiles.length > 0 ? profiles : [mapProfile(currentProfile)]}
+          items={calendarItems}
+          weekStart={toDateInputValue(weekStart)}
+        />
+      ) : (
+        <div className="rounded-[28px] border border-camp-forest/10 bg-white/85 p-6 text-sm text-slate-600 shadow-panel">
+          Your profile needs to finish syncing before the dashboard calendar can load.
+        </div>
       )}
     </AppShell>
   );

--- a/app/inventory/stock-movement-form.tsx
+++ b/app/inventory/stock-movement-form.tsx
@@ -31,26 +31,13 @@ function SubmitButton({ label, tone }: { label: string; tone: 'primary' | 'secon
       disabled={pending}
       aria-label={pending ? 'Saving inventory movement' : label}
       title={pending ? 'Saving inventory movement' : label}
-      className={`inline-flex size-10 items-center justify-center rounded-full transition hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70 ${
+      className={`inline-flex h-10 min-w-24 items-center justify-center rounded-full px-4 text-sm font-semibold transition hover:-translate-y-0.5 disabled:cursor-wait disabled:opacity-70 ${
         isPrimary
           ? 'bg-camp-forest text-white hover:bg-camp-forest/90'
           : 'bg-camp-sand/65 text-camp-forest hover:bg-camp-sand'
       }`}
     >
-      <svg
-        aria-hidden="true"
-        className="size-4"
-        fill="none"
-        stroke="currentColor"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="2"
-        viewBox="0 0 24 24"
-      >
-        {isPrimary ? <path d="M12 5v14" /> : null}
-        <path d="M5 12h14" />
-      </svg>
-      <span className="sr-only">{pending ? 'Saving inventory movement' : label}</span>
+      {pending ? 'Saving...' : label}
     </button>
   );
 }

--- a/supabase/migrations/20260411204401_personal_calendar_events.sql
+++ b/supabase/migrations/20260411204401_personal_calendar_events.sql
@@ -1,0 +1,57 @@
+create table if not exists public.personal_calendar_events (
+  id uuid primary key default gen_random_uuid(),
+  owner_profile_id uuid not null references public.profiles(id) on delete cascade,
+  title text not null,
+  starts_at timestamptz not null,
+  ends_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now()),
+  check (ends_at > starts_at)
+);
+
+create index if not exists personal_calendar_events_owner_starts_idx
+on public.personal_calendar_events (owner_profile_id, starts_at);
+
+drop trigger if exists set_personal_calendar_events_updated_at on public.personal_calendar_events;
+
+create trigger set_personal_calendar_events_updated_at
+before update on public.personal_calendar_events
+for each row execute function public.set_updated_at();
+
+alter table public.personal_calendar_events enable row level security;
+
+drop policy if exists "personal_calendar_events_owner_or_staff_read"
+on public.personal_calendar_events;
+
+create policy "personal_calendar_events_owner_or_staff_read"
+on public.personal_calendar_events
+for select
+using (
+  owner_profile_id = public.current_profile_id()
+  or public.has_any_role(array['super_admin', 'admin', 'staff'])
+);
+
+drop policy if exists "personal_calendar_events_owner_create"
+on public.personal_calendar_events;
+
+create policy "personal_calendar_events_owner_create"
+on public.personal_calendar_events
+for insert
+with check (owner_profile_id = public.current_profile_id());
+
+drop policy if exists "personal_calendar_events_owner_update"
+on public.personal_calendar_events;
+
+create policy "personal_calendar_events_owner_update"
+on public.personal_calendar_events
+for update
+using (owner_profile_id = public.current_profile_id())
+with check (owner_profile_id = public.current_profile_id());
+
+drop policy if exists "personal_calendar_events_owner_delete"
+on public.personal_calendar_events;
+
+create policy "personal_calendar_events_owner_delete"
+on public.personal_calendar_events
+for delete
+using (owner_profile_id = public.current_profile_id());


### PR DESCRIPTION
## Summary

- replace the dashboard registration list/empty state with a weekly calendar view
- show registered events and personal calendar events on the week grid with previous/next navigation and a live “Now” marker
- allow users to tap or drag a time range on their own calendar, then create a personal event from an inline composer
- allow staff/admin users to switch to another user’s calendar in read-only mode
- change inventory movement controls from icon-only +/- buttons to visible Add/Remove buttons

## Data model

Adds `personal_calendar_events` with owner-scoped RLS policies. Owners can create/update/delete their own personal events, while staff/admin users can read calendars for view-only inspection.

## Validation

- `pnpm -s lint`
- `pnpm -s typecheck`
- `pnpm -s test -- tests/events.test.ts tests/inventory-utils.test.ts`
- `pnpm -s build`
