### PR TITLE
[codex] Keep Supabase DB workflow from blocking on local diff

### DIFF
--- a/.github/workflows/supabase-db.yml
+++ b/.github/workflows/supabase-db.yml
@@ -34,7 +34,7 @@ jobs:
         run: supabase db lint --workdir supabase || echo "::warning::Supabase local lint skipped because no local database is running"
 
       - name: Dry-run migration generation check
-        run: supabase db diff --workdir supabase --schema public || true
+        run: timeout 30s supabase db diff --workdir supabase --schema public || echo "::warning::Supabase local diff skipped because no local database is running"
 
   deploy:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary

- prevent the Supabase DB validation workflow from hanging on local `db diff` when no local Supabase database is running
- keep the step advisory with a 30-second timeout so hosted migration deployment can proceed on `main`

## Validation

- workflow-only change; PR checks will validate the updated workflow syntax
