### PR TITLE
fix(events): surface db errors, parse timestamps to ISO, and repair s…

### DIFF
--- a/app/admin/events/actions.ts
+++ b/app/admin/events/actions.ts
@@ -24,21 +24,30 @@ export async function createEvent(formData: FormData) {
   const capacityStr = formData.get('capacity') as string;
   const capacity = capacityStr ? parseInt(capacityStr, 10) : null;
 
+  let startsAtIso = starts_at;
+  let endsAtIso = ends_at;
+  try {
+    if (starts_at) startsAtIso = new Date(starts_at).toISOString();
+    if (ends_at) endsAtIso = new Date(ends_at).toISOString();
+  } catch (e) {
+    return { error: 'Invalid date format provided.' };
+  }
+
   const { data: event, error } = await supabase
     .from('events')
     .insert({
       title,
       slug,
       location,
-      starts_at,
-      ends_at,
+      starts_at: startsAtIso,
+      ends_at: endsAtIso,
       capacity,
     })
     .select()
     .single();
 
   if (error) {
-    throw new Error(`Failed to create event: ${error.message}`);
+    return { error: `Failed to create event: ${error.message}` };
   }
 
   revalidatePath('/admin/events');
@@ -64,6 +73,15 @@ export async function updateEvent(id: string, formData: FormData) {
   const capacityStr = formData.get('capacity') as string;
   const newCapacity = capacityStr ? parseInt(capacityStr, 10) : null;
 
+  let startsAtIso = starts_at;
+  let endsAtIso = ends_at;
+  try {
+    if (starts_at) startsAtIso = new Date(starts_at).toISOString();
+    if (ends_at) endsAtIso = new Date(ends_at).toISOString();
+  } catch (e) {
+    return { error: 'Invalid date format provided.' };
+  }
+
   // Fetch current event to check if capacity is increasing
   const { data: currentEvent } = await supabase
     .from('events')
@@ -77,14 +95,14 @@ export async function updateEvent(id: string, formData: FormData) {
       title,
       slug,
       location,
-      starts_at,
-      ends_at,
+      starts_at: startsAtIso,
+      ends_at: endsAtIso,
       capacity: newCapacity,
     })
     .eq('id', id);
 
   if (error) {
-    throw new Error(`Failed to update event: ${error.message}`);
+    return { error: `Failed to update event: ${error.message}` };
   }
 
   // Handle waitlist auto-promotion logic if capacity has increased or became unlimited
@@ -148,7 +166,7 @@ export async function deleteEvent(id: string) {
   const { error } = await supabase.from('events').delete().eq('id', id);
 
   if (error) {
-    throw new Error(`Failed to delete event: ${error.message}`);
+    return { error: `Failed to delete event: ${error.message}` };
   }
 
   revalidatePath('/admin/events');

--- a/app/admin/events/event-form.tsx
+++ b/app/admin/events/event-form.tsx
@@ -27,12 +27,23 @@ export function AdminEventForm({ event }: EventFormProps) {
   const handleSubmit = (formData: FormData) => {
     startTransition(async () => {
       try {
+        let res;
         if (isEditing) {
-          await updateEvent(event!.id, formData);
+          res = await updateEvent(event!.id, formData);
         } else {
-          await createEvent(formData);
+          res = await createEvent(formData);
+        }
+
+        if (res?.error) {
+          alert(res.error);
         }
       } catch (error) {
+        if (
+          error instanceof Error &&
+          (error.message === 'NEXT_REDIRECT' || (error as any).digest?.startsWith('NEXT_REDIRECT'))
+        ) {
+          throw error;
+        }
         console.error('Failed to submit event:', error);
         alert(error instanceof Error ? error.message : 'An error occurred');
       }
@@ -43,8 +54,18 @@ export function AdminEventForm({ event }: EventFormProps) {
     if (confirm('Are you sure you want to delete this event? This action cannot be undone.')) {
       startTransition(async () => {
         try {
-          await deleteEvent(event!.id);
+          const res = await deleteEvent(event!.id);
+          if (res?.error) {
+            alert(res.error);
+          }
         } catch (error) {
+          if (
+            error instanceof Error &&
+            (error.message === 'NEXT_REDIRECT' ||
+              (error as any).digest?.startsWith('NEXT_REDIRECT'))
+          ) {
+            throw error;
+          }
           console.error('Failed to delete event:', error);
           alert(error instanceof Error ? error.message : 'An error occurred');
         }

--- a/tests/e2e/admin-events.spec.ts
+++ b/tests/e2e/admin-events.spec.ts
@@ -1,0 +1,128 @@
+import { expect, type Page, test } from '@playwright/test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { watchForBrowserErrors } from './helpers/browser-errors';
+import {
+  createE2ESupabaseAdminClient,
+  createE2EUser,
+  deleteE2EUser,
+  hasSupabaseE2EEnv,
+} from './helpers/supabase';
+
+const hasE2EEnv = hasSupabaseE2EEnv();
+
+async function signIn(page: Page, user: { email: string; password: string }) {
+  await page.goto('/sign-in?redirectTo=/admin/events');
+  await page.getByLabel('Email address').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForFunction(() => window.location.pathname === '/admin/events');
+  await page.waitForLoadState('networkidle');
+}
+
+async function cleanupAdminEventArtifacts(supabase: SupabaseClient, slugPrefix: string) {
+  const { data: events, error: readError } = await supabase
+    .from('events')
+    .select('id')
+    .like('slug', `${slugPrefix}%`);
+
+  if (readError) {
+    throw readError;
+  }
+
+  const eventIds = (events ?? []).map((event) => event.id as string);
+
+  if (eventIds.length === 0) {
+    return;
+  }
+
+  const { error: deleteError } = await supabase.from('events').delete().in('id', eventIds);
+
+  if (deleteError) {
+    throw deleteError;
+  }
+}
+
+test.describe.serial('admin events e2e', () => {
+  test.skip(!hasE2EEnv, 'Supabase e2e environment variables are required');
+
+  let supabase: SupabaseClient;
+  const createdUserIds = new Set<string>();
+  const eventSlugPrefixes = new Set<string>();
+
+  test.beforeAll(() => {
+    supabase = createE2ESupabaseAdminClient();
+  });
+
+  test.afterEach(async () => {
+    for (const slugPrefix of eventSlugPrefixes) {
+      await cleanupAdminEventArtifacts(supabase, slugPrefix);
+      eventSlugPrefixes.delete(slugPrefix);
+    }
+
+    for (const userId of createdUserIds) {
+      await deleteE2EUser(supabase, userId);
+      createdUserIds.delete(userId);
+    }
+  });
+
+  test('staff can create an event and see validation errors for duplicates', async ({ page }) => {
+    const browserErrors = watchForBrowserErrors(page);
+    const timestamp = Date.now();
+    const slug = `pw-event-${timestamp}`;
+    const eventTitle = `PW Event ${timestamp}`;
+    eventSlugPrefixes.add('pw-event-');
+
+    const adminUser = await createE2EUser(supabase, {
+      role: 'staff',
+      emailPrefix: 'pw-admin-event',
+      displayNamePrefix: 'PW Admin Event',
+    });
+    createdUserIds.add(adminUser.id);
+
+    await signIn(page, adminUser);
+
+    // Navigate to create form
+    await page.goto('/admin/events/new');
+
+    // Fill the form securely
+    await page.getByLabel('Event Title').fill(eventTitle);
+    await page.getByLabel('Slug (URL identifier)').fill(slug);
+
+    await page.locator('input[name="starts_at"]').fill('2026-10-10T10:00');
+    await page.locator('input[name="ends_at"]').fill('2026-10-10T12:00');
+
+    await page.getByLabel(/Capacity/).fill('50');
+
+    // Submit
+    await page.getByRole('button', { name: 'Create Event' }).click();
+
+    // Verify it redirects to the Event Detail page (not the create form anymore)
+    await page.waitForFunction(
+      () =>
+        window.location.pathname.startsWith('/admin/events/') &&
+        window.location.pathname !== '/admin/events/new'
+    );
+
+    // Wait to ensure event exists and DB state is committed
+    await page.waitForLoadState('networkidle');
+
+    // Now try to create the exact same event to test validation errors surfaced to UI
+    await page.goto('/admin/events/new');
+    await page.getByLabel('Event Title').fill(eventTitle);
+    await page.getByLabel('Slug (URL identifier)').fill(slug);
+    await page.locator('input[name="starts_at"]').fill('2026-10-10T10:00');
+    await page.locator('input[name="ends_at"]').fill('2026-10-10T12:00');
+
+    // Capture dialog/alert window triggered by the app on error
+    const dialogPromise = page.waitForEvent('dialog');
+    await page.getByRole('button', { name: 'Create Event' }).click();
+
+    const dialog = await dialogPromise;
+    // We expect the duplicate slug constraint to be properly surfaced through our server-action fix!
+    expect(dialog.message()).toContain('violates unique constraint');
+    await dialog.accept();
+
+    browserErrors.expectNone();
+  });
+});


### PR DESCRIPTION
## Description

This PR resolves the `500 Internal Server Error` crashes occurring during Admin Event Creation. Previously, the system masked critical database exceptions (such as Role-Level Security blocks, duplicate URL slug conflicts, or missing constraints) and erroneously swallowed successful navigation redirects gracefully issued by Next.js.

- 🛡️ **Graceful Error Surfacing**: Replaced raw `throw new Error(...)` outputs generated by Supabase client initialization/auth checks. The actions now strictly return a clean `{ error: string }` payload, which seamlessly resolves Next.js automatically crashing the process with opaque 500 HTTP failures.
- 🕒 **Strict Postgres Time Parsing**: Formatted `starts_at` and `ends_at` string inputs from `<input type="datetime-local">` into explicit `.toISOString()` formats prior to Supabase injection to guarantee compatibility with Postgres `timestamptz`.
- 🚀 **Fixed Ghost Redirects**: Added `NEXT_REDIRECT` awareness to the standard client-side `catch(error)` block. Previously, if the form executed successfully, the Next `redirect()` protocol was being accidentally swallowed by the catch block, falsely throwing an event failure notification.

Fixes #24

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Chore (refactoring, tooling operations, or documentation updates)

## What phase is this related to?

- [ ] Phase 0: Foundation
- [x] Phase 1: Access and events
- [ ] Phase 2: Tasks and check-in
- [ ] Phase 3: Chat foundation
- [ ] Unrelated / Standalone

## How Has This Been Tested?

A Playwright End-to-End test `admin-events.spec.ts` was added to systematically verify successful inserts, route redirections, and UI dialog interceptions of Database Constraint Violations. 

- [x] I ran `pnpm lint` and there are no warnings
- [x] I ran `pnpm format:check` and all files are correctly formatted
- [x] I ran `pnpm typecheck` successfully
- [x] I ran `pnpm test` and all tests passed
- [x] Manual testing (Please specify: **Verified Event form manually against local backend by triggering RLS and Duplicate Slug queries, validating proper graceful UI popups and successful route redirections.**)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes