### PR TITLE
fix(roles): refresh session JWT after self-role-change

### DIFF
--- a/app/dev-tools/users/actions.ts
+++ b/app/dev-tools/users/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import { normalizeRoleActionInput } from '@/lib/dev-tools/user-directory';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { createSupabaseServerClient } from '@/lib/supabase/server';
 
 export type ChangeUserRoleState = {
   status: 'idle' | 'success' | 'error';
@@ -105,14 +106,20 @@ export async function changeUserRole(
     }
   }
 
-  revalidatePath('/dev-tools/users');
-  revalidatePath('/profile');
+  // When the current user changes their own role, refresh their session so the
+  // browser cookie JWT carries the updated app_metadata immediately.
+  if (userId === currentUserId) {
+    const userClient = await createSupabaseServerClient();
+    await userClient?.auth.refreshSession();
+  }
+
+  revalidatePath('/', 'layout');
 
   return {
     status: 'success',
     message:
       userId === currentUserId
-        ? 'User role updated successfully. Reload the app if your own navigation should change immediately.'
+        ? `Role updated to ${targetRole.replace('_', ' ')}. The app will refresh automatically.`
         : 'User role updated successfully.',
     role: targetRole,
     submittedAt: Date.now(),

--- a/app/dev-tools/users/role-change-form.tsx
+++ b/app/dev-tools/users/role-change-form.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState, useEffect, useState } from 'react';
 import { useFormStatus } from 'react-dom';
+import { useRouter } from 'next/navigation';
 
 import { appRoles, type AppRole } from '@/lib/app-config';
 
@@ -41,6 +42,7 @@ export function RoleChangeForm({
   currentAuthUserId: string;
   initialRole: AppRole;
 }) {
+  const router = useRouter();
   const [selectedRole, setSelectedRole] = useState<AppRole>(initialRole);
   const [state, formAction] = useActionState(changeUserRole, initialState);
   const messageTone =
@@ -51,8 +53,12 @@ export function RoleChangeForm({
   useEffect(() => {
     if (state.status === 'success' && state.role) {
       setSelectedRole(normalizeSelectRole(state.role));
+      // Force Next.js to re-render all server components so the sidebar,
+      // middleware checks, and every other role-aware surface pick up the
+      // updated role immediately — no manual reload required.
+      router.refresh();
     }
-  }, [state.role, state.status]);
+  }, [state.role, state.status, router]);
 
   useEffect(() => {
     setSelectedRole(initialRole);

--- a/tests/e2e/account.spec.ts
+++ b/tests/e2e/account.spec.ts
@@ -95,7 +95,7 @@ test.describe.serial('account e2e', () => {
 
     await expect(
       currentUserRow.getByText(
-        'User role updated successfully. Reload the app if your own navigation should change immediately.'
+        'Role updated to admin. The app will refresh automatically.'
       )
     ).toBeVisible();
     await expect(page).toHaveURL(/\/dev-tools\/users$/);

--- a/tests/e2e/role-change.spec.ts
+++ b/tests/e2e/role-change.spec.ts
@@ -1,0 +1,135 @@
+import { expect, type Page, test } from '@playwright/test';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import { watchForBrowserErrors } from './helpers/browser-errors';
+import {
+  createE2ESupabaseAdminClient,
+  createE2EUser,
+  deleteE2EUser,
+  hasSupabaseE2EEnv,
+} from './helpers/supabase';
+
+const hasE2EEnv = hasSupabaseE2EEnv();
+
+async function signIn(page: Page, user: { email: string; password: string }) {
+  await page.goto('/sign-in?redirectTo=/dashboard');
+  await page.getByLabel('Email address').fill(user.email);
+  await page.getByLabel('Password').fill(user.password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForFunction(() => window.location.pathname === '/dashboard');
+  await page.waitForLoadState('networkidle');
+}
+
+test.describe.serial('role change e2e', () => {
+  test.skip(!hasE2EEnv, 'Supabase e2e environment variables are required');
+
+  let supabase: SupabaseClient;
+  const createdUserIds = new Set<string>();
+
+  test.beforeAll(() => {
+    supabase = createE2ESupabaseAdminClient();
+  });
+
+  test.afterEach(async () => {
+    for (const userId of createdUserIds) {
+      await deleteE2EUser(supabase, userId);
+      createdUserIds.delete(userId);
+    }
+  });
+
+  test('self-role-change to super_admin is recognized immediately without reload', async ({
+    page,
+  }) => {
+    const browserErrors = watchForBrowserErrors(page);
+    const user = await createE2EUser(supabase, {
+      role: 'admin',
+      emailPrefix: 'pw-upgrade',
+      displayNamePrefix: 'PW Upgrade',
+    });
+    createdUserIds.add(user.id);
+
+    await signIn(page, user);
+
+    // Navigate to Dev Tools user directory and change own role to super_admin
+    await page.goto('/dev-tools/users');
+    await page.waitForLoadState('networkidle');
+
+    const currentUserRow = page
+      .getByText(user.email, { exact: true })
+      .locator('xpath=ancestor::tr[1]');
+    await expect(currentUserRow).toBeVisible();
+    await currentUserRow.getByLabel('Change role').selectOption('super_admin');
+    await expect(currentUserRow.getByLabel('Change role')).toHaveValue('super_admin');
+    await currentUserRow.getByRole('button', { name: 'Save' }).click();
+
+    // Verify success message does NOT tell the user to reload
+    await expect(
+      currentUserRow.getByText('Role updated to super admin. The app will refresh automatically.')
+    ).toBeVisible();
+    await expect(
+      page.getByText('Reload the app if your own navigation should change immediately.')
+    ).toHaveCount(0);
+    await expect(currentUserRow.getByLabel('Change role')).toHaveValue('super_admin');
+    await expect(page.getByText('The role change could not be completed.')).toHaveCount(0);
+
+    // Navigate to the profile page and verify the new role is active
+    await page.goto('/profile');
+    await page.waitForLoadState('networkidle');
+    const main = page.getByRole('main');
+    await expect(main.getByText(user.email, { exact: true })).toBeVisible();
+    await expect(main.getByText('super admin', { exact: true })).toBeVisible();
+
+    // Verify the sidebar shows role-restricted nav items (Admin + Inventory require staffPrivilegedRoles)
+    const sidebar = page.locator('aside');
+    await expect(sidebar.getByText('Admin', { exact: true })).toBeVisible();
+    await expect(sidebar.getByText('Inventory', { exact: true })).toBeVisible();
+
+    browserErrors.expectNone();
+  });
+
+  test('role downgrade from super_admin to participant restricts access', async ({ page }) => {
+    const browserErrors = watchForBrowserErrors(page);
+    const user = await createE2EUser(supabase, {
+      role: 'super_admin',
+      emailPrefix: 'pw-downgrade',
+      displayNamePrefix: 'PW Downgrade',
+    });
+    createdUserIds.add(user.id);
+
+    await signIn(page, user);
+
+    // Navigate to Dev Tools and downgrade own role to participant
+    await page.goto('/dev-tools/users');
+    await page.waitForLoadState('networkidle');
+
+    const currentUserRow = page
+      .getByText(user.email, { exact: true })
+      .locator('xpath=ancestor::tr[1]');
+    await expect(currentUserRow).toBeVisible();
+    await currentUserRow.getByLabel('Change role').selectOption('participant');
+    await expect(currentUserRow.getByLabel('Change role')).toHaveValue('participant');
+    await currentUserRow.getByRole('button', { name: 'Save' }).click();
+
+    await expect(
+      currentUserRow.getByText(
+        'Role updated to participant. The app will refresh automatically.'
+      )
+    ).toBeVisible();
+
+    // Navigate to the dashboard and verify restricted nav items are hidden
+    await page.goto('/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    const sidebar = page.locator('aside');
+    await expect(sidebar.getByText('Dashboard', { exact: true })).toBeVisible();
+    await expect(sidebar.getByText('Admin', { exact: true })).toHaveCount(0);
+    await expect(sidebar.getByText('Inventory', { exact: true })).toHaveCount(0);
+
+    // Attempting to access /admin should redirect to /dashboard
+    await page.goto('/admin');
+    await page.waitForLoadState('networkidle');
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    browserErrors.expectNone();
+  });
+});


### PR DESCRIPTION
## Problem

When a user changed their own role to super_admin via Dev Tools, the admin API updated `app_metadata` in the database but the browser session JWT kept the old role. The stale JWT meant middleware, sidebar nav, and every other role-aware surface continued seeing the previous role until a manual page reload.

## Root Cause

- `changeUserRole` server action never refreshed the user's Supabase session after the admin API update
- `revalidatePath` only covered `/dev-tools/users` and `/profile`, leaving the rest of the app with cached pages showing the old role
- The existing code acknowledged this with the message *"Reload the app if your own navigation should change immediately."*

## Fix

- **Server action**: After a self-role-change, calls `auth.refreshSession()` via the user-context Supabase client → new JWT with updated `app_metadata` gets written to cookies
- **Server action**: Replaced narrow `revalidatePath` calls with `revalidatePath('/', 'layout')` to invalidate all cached pages/layouts
- **Client component**: Added `router.refresh()` on success → forces Next.js to re-render all server components immediately
- **Success message**: Updated from manual reload instruction to *"Role updated to {role}. The app will refresh automatically."*

## Tests

- **Upgrade test**: admin → super_admin, verifies role recognized on profile + admin/inventory nav visible in sidebar
- **Downgrade test**: super_admin → participant, verifies admin/inventory nav hidden + middleware blocks `/admin` access