### PR TITLE
fix: use admin client for staff event/attendance management

### DIFF
--- a/app/admin/events/[id]/registrations/actions.ts
+++ b/app/admin/events/[id]/registrations/actions.ts
@@ -2,19 +2,46 @@
 
 import { revalidatePath } from 'next/cache';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { staffPrivilegedRoles, type AppRole } from '@/lib/app-config';
 import { appendAdminCancellationReason } from '@/lib/events/admin-utils';
+import { determineRegistrationStatus } from '@/lib/events/registration-utils';
 
-export async function adminForcePromoteWaitlist(eventId: string, userId: string) {
+/**
+ * Verifies the calling user is authenticated and has a staff+ role.
+ * Returns the authenticated user object.
+ */
+async function requireStaffUser() {
   const supabase = await createSupabaseServerClient();
   if (!supabase) throw new Error('Supabase client unavailable');
 
-  // Validate admin/staff session
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) throw new Error('Not authenticated');
 
-  const { error } = await supabase
+  const role = (user.app_metadata?.role as string) ?? 'participant';
+  if (!staffPrivilegedRoles.includes(role as AppRole)) {
+    throw new Error('Insufficient permissions');
+  }
+
+  return user;
+}
+
+/**
+ * Returns the admin (service-role) Supabase client, or throws.
+ */
+function requireAdminClient() {
+  const adminClient = createSupabaseAdminClient();
+  if (!adminClient) throw new Error('Admin client unavailable');
+  return adminClient;
+}
+
+export async function adminForcePromoteWaitlist(eventId: string, userId: string) {
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
+
+  const { error } = await adminClient
     .from('event_registrations')
     .update({ status: 'registered' })
     .match({ event_id: eventId, user_id: userId });
@@ -28,17 +55,11 @@ export async function adminForcePromoteWaitlist(eventId: string, userId: string)
 }
 
 export async function adminCancelRegistration(eventId: string, userId: string, reason: string) {
-  const supabase = await createSupabaseServerClient();
-  if (!supabase) throw new Error('Supabase client unavailable');
-
-  // Validate admin/staff session
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
 
   // Fetch current registration to get status and existing notes
-  const { data: currentReg } = await supabase
+  const { data: currentReg } = await adminClient
     .from('event_registrations')
     .select('status, notes')
     .match({ event_id: eventId, user_id: userId })
@@ -54,7 +75,7 @@ export async function adminCancelRegistration(eventId: string, userId: string, r
     newNotesStr = appendAdminCancellationReason(currentReg.notes, reason);
   }
 
-  const { error } = await supabase
+  const { error } = await adminClient
     .from('event_registrations')
     .update({
       status: 'cancelled',
@@ -66,16 +87,16 @@ export async function adminCancelRegistration(eventId: string, userId: string, r
     throw new Error(`Failed to cancel registration: ${error.message}`);
   }
 
-  // Handle auto-promotion logic if a registered user cancelled!
+  // Handle auto-promotion logic if a registered user cancelled
   if (currentReg.status === 'registered') {
-    const { data: event } = await supabase
+    const { data: event } = await adminClient
       .from('events')
       .select('capacity')
       .eq('id', eventId)
       .single();
 
     if (event && event.capacity !== null) {
-      const { count: registeredCount } = await supabase
+      const { count: registeredCount } = await adminClient
         .from('event_registrations')
         .select('*', { count: 'exact', head: true })
         .eq('event_id', eventId)
@@ -83,7 +104,7 @@ export async function adminCancelRegistration(eventId: string, userId: string, r
 
       if (registeredCount !== null && registeredCount < event.capacity) {
         // Promote the earliest waitlisted entry
-        const { data: nextInLine } = await supabase
+        const { data: nextInLine } = await adminClient
           .from('event_registrations')
           .select('user_id')
           .eq('event_id', eventId)
@@ -93,7 +114,7 @@ export async function adminCancelRegistration(eventId: string, userId: string, r
           .single();
 
         if (nextInLine) {
-          await supabase
+          await adminClient
             .from('event_registrations')
             .update({ status: 'registered' })
             .match({ event_id: eventId, user_id: nextInLine.user_id });
@@ -104,4 +125,66 @@ export async function adminCancelRegistration(eventId: string, userId: string, r
 
   revalidatePath(`/admin/events/${eventId}/registrations`);
   revalidatePath(`/events/${eventId}`);
+}
+
+/**
+ * Manually registers a user for an event. Staff can register anyone.
+ * Respects capacity — if full, the user is waitlisted.
+ */
+export async function adminManualRegister(eventId: string, userId: string) {
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
+
+  // Check if user already has an active registration
+  const { data: existingReg } = await adminClient
+    .from('event_registrations')
+    .select('status')
+    .match({ event_id: eventId, user_id: userId })
+    .maybeSingle();
+
+  if (existingReg && (existingReg.status === 'registered' || existingReg.status === 'waitlisted')) {
+    throw new Error('User already has an active registration for this event');
+  }
+
+  // Fetch event to check capacity
+  const { data: event } = await adminClient
+    .from('events')
+    .select('capacity')
+    .eq('id', eventId)
+    .single();
+
+  if (!event) {
+    throw new Error('Event not found');
+  }
+
+  // Count current registrations to determine status
+  let registeredCount: number | null = null;
+  if (event.capacity !== null) {
+    const { count } = await adminClient
+      .from('event_registrations')
+      .select('*', { count: 'exact', head: true })
+      .eq('event_id', eventId)
+      .eq('status', 'registered');
+    registeredCount = count;
+  }
+
+  const newStatus = determineRegistrationStatus(event.capacity, registeredCount);
+
+  const { error } = await adminClient.from('event_registrations').upsert(
+    {
+      event_id: eventId,
+      user_id: userId,
+      status: newStatus,
+      registered_at: new Date().toISOString(),
+    },
+    { onConflict: 'event_id,user_id' }
+  );
+
+  if (error) {
+    throw new Error(`Failed to register user: ${error.message}`);
+  }
+
+  revalidatePath(`/admin/events/${eventId}/registrations`);
+  revalidatePath(`/events/${eventId}`);
+  revalidatePath('/events');
 }

--- a/app/admin/events/[id]/registrations/add-participant-form.tsx
+++ b/app/admin/events/[id]/registrations/add-participant-form.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import { adminManualRegister } from './actions';
+
+type Profile = {
+  id: string;
+  displayName: string;
+  email: string;
+};
+
+type AddParticipantFormProps = {
+  eventId: string;
+  profiles: Profile[];
+  existingUserIds: string[];
+};
+
+export function AddParticipantForm({
+  eventId,
+  profiles,
+  existingUserIds,
+}: AddParticipantFormProps) {
+  const [isPending, startTransition] = useTransition();
+  const [search, setSearch] = useState('');
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showDropdown, setShowDropdown] = useState(false);
+
+  const existingSet = new Set(existingUserIds);
+  const availableProfiles = profiles.filter((p) => !existingSet.has(p.id));
+  const filteredProfiles = availableProfiles.filter(
+    (p) =>
+      p.displayName.toLowerCase().includes(search.toLowerCase()) ||
+      p.email.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const selectedProfile = profiles.find((p) => p.id === selectedId);
+
+  const handleRegister = () => {
+    if (!selectedId) return;
+    startTransition(async () => {
+      try {
+        await adminManualRegister(eventId, selectedId);
+        setSelectedId(null);
+        setSearch('');
+      } catch (e: any) {
+        alert('Failed to register: ' + e.message);
+      }
+    });
+  };
+
+  return (
+    <div className="rounded-[24px] border border-camp-forest/10 bg-white/85 p-6 shadow-panel">
+      <h3 className="mb-3 font-serif text-lg text-camp-forest">Add Participant</h3>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="relative flex-1">
+          <label className="mb-1 block text-sm font-medium text-camp-forest" htmlFor="add-user">
+            Search user
+          </label>
+          <input
+            id="add-user"
+            type="text"
+            value={
+              selectedProfile ? `${selectedProfile.displayName} (${selectedProfile.email})` : search
+            }
+            onChange={(e) => {
+              setSearch(e.target.value);
+              setSelectedId(null);
+              setShowDropdown(true);
+            }}
+            onFocus={() => setShowDropdown(true)}
+            placeholder="Type a name or email…"
+            className="w-full rounded-md border border-slate-300 p-2 text-sm focus:border-camp-forest focus:outline-none focus:ring-1 focus:ring-camp-forest"
+          />
+          {showDropdown && !selectedId && search.length > 0 && filteredProfiles.length > 0 && (
+            <ul className="absolute z-10 mt-1 max-h-48 w-full overflow-auto rounded-md border border-slate-200 bg-white shadow-lg">
+              {filteredProfiles.slice(0, 10).map((p) => (
+                <li key={p.id}>
+                  <button
+                    type="button"
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-camp-forest/5"
+                    onClick={() => {
+                      setSelectedId(p.id);
+                      setSearch('');
+                      setShowDropdown(false);
+                    }}
+                  >
+                    <span className="font-medium">{p.displayName}</span>{' '}
+                    <span className="text-slate-500">({p.email})</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={handleRegister}
+          disabled={!selectedId || isPending}
+          className="rounded-full bg-camp-forest px-6 py-2 text-sm font-medium text-white transition hover:bg-camp-forest/90 disabled:opacity-50"
+        >
+          {isPending ? 'Adding…' : 'Register'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/events/[id]/registrations/attendee-row.tsx
+++ b/app/admin/events/[id]/registrations/attendee-row.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useTransition } from 'react';
-import { adminForcePromoteWaitlist, adminCancelRegistration } from './actions';
+import { adminForcePromoteWaitlist, adminCancelRegistration, adminManualRegister } from './actions';
 
 export function AttendeeRow({ eventId, attendee }: { eventId: string; attendee: any }) {
   const [isPending, startTransition] = useTransition();
@@ -31,6 +31,18 @@ export function AttendeeRow({ eventId, attendee }: { eventId: string; attendee: 
     }
   };
 
+  const handleReRegister = () => {
+    if (confirm('Re-register this user for the event?')) {
+      startTransition(async () => {
+        try {
+          await adminManualRegister(eventId, attendee.user_id || attendee.profiles?.id);
+        } catch (e: any) {
+          alert('Failed to re-register: ' + e.message);
+        }
+      });
+    }
+  };
+
   let parsedNotes: any = null;
   if (attendee.notes) {
     try {
@@ -49,6 +61,11 @@ export function AttendeeRow({ eventId, attendee }: { eventId: string; attendee: 
             {!attendee.profiles?.first_name &&
               !attendee.profiles?.last_name &&
               attendee.profiles?.display_name}
+            {attendee.is_mandatory && (
+              <span className="ml-2 inline-block rounded-full bg-camp-forest/10 px-2 py-0.5 text-xs font-medium text-camp-forest">
+                Mandatory
+              </span>
+            )}
           </h3>
           <p className="text-sm text-slate-500">{attendee.profiles?.email}</p>
         </div>
@@ -73,6 +90,16 @@ export function AttendeeRow({ eventId, attendee }: { eventId: string; attendee: 
               className="rounded-md border border-red-200 bg-white px-2 py-1 font-medium text-red-600 transition hover:bg-red-50 disabled:opacity-50"
             >
               Cancel
+            </button>
+          )}
+
+          {attendee.status === 'cancelled' && (
+            <button
+              onClick={handleReRegister}
+              disabled={isPending}
+              className="rounded-md border border-camp-forest bg-white px-2 py-1 font-medium text-camp-forest transition hover:bg-camp-forest/5 disabled:opacity-50"
+            >
+              Re-register
             </button>
           )}
         </div>

--- a/app/admin/events/[id]/registrations/page.tsx
+++ b/app/admin/events/[id]/registrations/page.tsx
@@ -1,6 +1,8 @@
 import { AppShell } from '@/components/layout/app-shell';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
-import { notFound } from 'next/navigation';
+import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { staffPrivilegedRoles, type AppRole } from '@/lib/app-config';
+import { notFound, redirect } from 'next/navigation';
 
 type AdminEventRegistrationsProps = {
   params: Promise<{
@@ -9,6 +11,7 @@ type AdminEventRegistrationsProps = {
 };
 
 import { AttendeeRow } from './attendee-row';
+import { AddParticipantForm } from './add-participant-form';
 
 // Internal component for listing attendees by status
 function AttendeeList({
@@ -48,10 +51,28 @@ export default async function AdminEventRegistrationsPage({
   params,
 }: AdminEventRegistrationsProps) {
   const { id } = await params;
+
+  // Verify user is authenticated and staff+
   const supabase = await createSupabaseServerClient();
   if (!supabase) return null;
 
-  const { data: event } = await supabase
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    redirect('/sign-in');
+  }
+
+  const role = (user.app_metadata?.role as string) ?? 'participant';
+  if (!staffPrivilegedRoles.includes(role as AppRole)) {
+    redirect('/dashboard');
+  }
+
+  // Use admin client for all DB reads to bypass RLS
+  const adminClient = createSupabaseAdminClient();
+  if (!adminClient) return null;
+
+  const { data: event } = await adminClient
     .from('events')
     .select('title, capacity')
     .eq('id', id)
@@ -59,33 +80,53 @@ export default async function AdminEventRegistrationsPage({
 
   if (!event) return notFound();
 
-  const { data: registrations } = await supabase
-    .from('event_registrations')
-    .select(
+  const [{ data: registrations }, { data: profileRows }] = await Promise.all([
+    adminClient
+      .from('event_registrations')
+      .select(
+        `
+        id,
+        user_id,
+        status,
+        notes,
+        is_mandatory,
+        registered_at,
+        profiles (
+          id,
+          first_name,
+          last_name,
+          email,
+          display_name
+        )
       `
-      id,
-      status,
-      notes,
-      registered_at,
-      profiles (
-        first_name,
-        last_name,
-        email,
-        display_name
       )
-    `
-    )
-    .eq('event_id', id)
-    .order('registered_at', { ascending: true });
+      .eq('event_id', id)
+      .order('registered_at', { ascending: true }),
+    adminClient
+      .from('profiles')
+      .select('id, display_name, email')
+      .order('display_name', { ascending: true }),
+  ]);
+
+  const profiles = (profileRows ?? []).map((row: any) => ({
+    id: row.id as string,
+    displayName: (row.display_name as string) ?? (row.email as string)?.split('@')[0] ?? 'User',
+    email: (row.email as string) ?? '',
+  }));
+
+  const existingUserIds = (registrations ?? [])
+    .filter((r: any) => r.status !== 'cancelled')
+    .map((r: any) => r.user_id as string);
 
   const grouped = {
-    registered: registrations?.filter((r) => r.status === 'registered') || [],
-    waitlisted: registrations?.filter((r) => r.status === 'waitlisted') || [],
-    cancelled: registrations?.filter((r) => r.status === 'cancelled') || [],
+    registered: registrations?.filter((r: any) => r.status === 'registered') || [],
+    waitlisted: registrations?.filter((r: any) => r.status === 'waitlisted') || [],
+    cancelled: registrations?.filter((r: any) => r.status === 'cancelled') || [],
   };
 
   return (
     <AppShell title={`Registrations`} eyebrow={event.title}>
+      <AddParticipantForm eventId={id} profiles={profiles} existingUserIds={existingUserIds} />
       <AttendeeList
         eventId={id}
         title="Registered"

--- a/app/admin/events/actions.ts
+++ b/app/admin/events/actions.ts
@@ -4,8 +4,39 @@ import { revalidatePath } from 'next/cache';
 import { redirect } from 'next/navigation';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 import { createSupabaseAdminClient } from '@/lib/supabase/admin';
+import { staffPrivilegedRoles, type AppRole } from '@/lib/app-config';
 import { pickNextInLine } from '@/lib/events/registration-utils';
 import { calculatePromotionAvailableSpots } from '@/lib/events/admin-utils';
+
+/**
+ * Verifies the calling user is authenticated and has a staff+ role.
+ * Returns the authenticated user object.
+ */
+async function requireStaffUser() {
+  const supabase = await createSupabaseServerClient();
+  if (!supabase) throw new Error('Supabase client unavailable');
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error('Not authenticated');
+
+  const role = (user.app_metadata?.role as string) ?? 'participant';
+  if (!staffPrivilegedRoles.includes(role as AppRole)) {
+    throw new Error('Insufficient permissions');
+  }
+
+  return user;
+}
+
+/**
+ * Returns the admin (service-role) Supabase client, or throws.
+ */
+function requireAdminClient() {
+  const adminClient = createSupabaseAdminClient();
+  if (!adminClient) throw new Error('Admin client unavailable');
+  return adminClient;
+}
 
 /**
  * Syncs mandatory participant registrations for an event.
@@ -16,13 +47,11 @@ import { calculatePromotionAvailableSpots } from '@/lib/events/admin-utils';
  * - Removed mandatory participants get is_mandatory set to false (their registration stays)
  */
 async function syncMandatoryParticipants(eventId: string, mandatoryProfileIds: string[]) {
-  const adminSupabase = createSupabaseAdminClient();
-  if (!adminSupabase) return;
-
+  const adminClient = requireAdminClient();
   const mandatorySet = new Set(mandatoryProfileIds);
 
   // Fetch existing mandatory registrations for this event
-  const { data: existingMandatory } = await adminSupabase
+  const { data: existingMandatory } = await adminClient
     .from('event_registrations')
     .select('user_id')
     .eq('event_id', eventId)
@@ -36,7 +65,7 @@ async function syncMandatoryParticipants(eventId: string, mandatoryProfileIds: s
 
   // Upsert new mandatory participants — always registered status
   for (const profileId of toAdd) {
-    await adminSupabase.from('event_registrations').upsert(
+    await adminClient.from('event_registrations').upsert(
       {
         event_id: eventId,
         user_id: profileId,
@@ -50,7 +79,7 @@ async function syncMandatoryParticipants(eventId: string, mandatoryProfileIds: s
 
   // Remove mandatory flag from removed participants (keep their registration)
   for (const profileId of toRemove) {
-    await adminSupabase
+    await adminClient
       .from('event_registrations')
       .update({ is_mandatory: false })
       .match({ event_id: eventId, user_id: profileId });
@@ -58,14 +87,8 @@ async function syncMandatoryParticipants(eventId: string, mandatoryProfileIds: s
 }
 
 export async function createEvent(formData: FormData) {
-  const supabase = await createSupabaseServerClient();
-  if (!supabase) throw new Error('Supabase client unavailable');
-
-  // Validate admin/staff session
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
 
   const title = formData.get('title') as string;
   const slug = formData.get('slug') as string;
@@ -88,7 +111,7 @@ export async function createEvent(formData: FormData) {
     return { error: 'Invalid date format provided.' };
   }
 
-  const { data: event, error } = await supabase
+  const { data: event, error } = await adminClient
     .from('events')
     .insert({
       title,
@@ -116,14 +139,8 @@ export async function createEvent(formData: FormData) {
 }
 
 export async function updateEvent(id: string, formData: FormData) {
-  const supabase = await createSupabaseServerClient();
-  if (!supabase) throw new Error('Supabase client unavailable');
-
-  // Validate admin/staff session
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
 
   const title = formData.get('title') as string;
   const slug = formData.get('slug') as string;
@@ -147,13 +164,13 @@ export async function updateEvent(id: string, formData: FormData) {
   }
 
   // Fetch current event to check if capacity is increasing
-  const { data: currentEvent } = await supabase
+  const { data: currentEvent } = await adminClient
     .from('events')
     .select('capacity')
     .eq('id', id)
     .single();
 
-  const { error } = await supabase
+  const { error } = await adminClient
     .from('events')
     .update({
       title,
@@ -179,14 +196,14 @@ export async function updateEvent(id: string, formData: FormData) {
     (newCapacity === null || newCapacity > currentEvent.capacity)
   ) {
     // Determine how many spots we can fill
-    const { count: registeredCount } = await supabase
+    const { count: registeredCount } = await adminClient
       .from('event_registrations')
       .select('*', { count: 'exact', head: true })
       .eq('event_id', id)
       .eq('status', 'registered');
 
     if (registeredCount !== null && (newCapacity === null || registeredCount < newCapacity)) {
-      const { data: waitlistedUsers } = await supabase
+      const { data: waitlistedUsers } = await adminClient
         .from('event_registrations')
         .select('user_id, registered_at')
         .eq('event_id', id)
@@ -203,7 +220,7 @@ export async function updateEvent(id: string, formData: FormData) {
         let p = 0;
         while (p < spotsToFill && p < waitlistedUsers.length) {
           const nextUser = waitlistedUsers[p];
-          await supabase
+          await adminClient
             .from('event_registrations')
             .update({ status: 'registered' })
             .match({ event_id: id, user_id: nextUser.user_id });
@@ -221,16 +238,10 @@ export async function updateEvent(id: string, formData: FormData) {
 }
 
 export async function deleteEvent(id: string) {
-  const supabase = await createSupabaseServerClient();
-  if (!supabase) throw new Error('Supabase client unavailable');
+  await requireStaffUser();
+  const adminClient = requireAdminClient();
 
-  // Validate admin/staff session
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) throw new Error('Not authenticated');
-
-  const { error } = await supabase.from('events').delete().eq('id', id);
+  const { error } = await adminClient.from('events').delete().eq('id', id);
 
   if (error) {
     return { error: `Failed to delete event: ${error.message}` };


### PR DESCRIPTION
## Summary

Fixes staff access to event and attendance management by switching all admin actions to use the service-role Supabase client, bypassing RLS policies that rely on the `user_roles` table (which doesn't match `app_metadata`-based role assignments).

### Changes

**Admin Event Actions (`app/admin/events/actions.ts`):**
- `createEvent`, `updateEvent`, `deleteEvent` now use admin client for DB writes
- Added explicit staff+ role check via `app_metadata.role` (not relying on RLS)
- Extracted shared `requireStaffUser()` and `requireAdminClient()` helpers

**Registration Management Actions (`app/admin/events/[id]/registrations/actions.ts`):**
- `adminForcePromoteWaitlist` and `adminCancelRegistration` use admin client
- New `adminManualRegister` action — staff can register any user for an event (respects capacity/waitlist)
- Same `requireStaffUser()` pattern for auth + role verification

**Registration Management Page (`app/admin/events/[id]/registrations/page.tsx`):**
- Reads use admin client so staff can see all registrations
- Added `AddParticipantForm` — searchable user picker to manually register participants

**Attendee Row (`attendee-row.tsx`):**
- Shows `Mandatory` badge for mandatory attendees
- Added `Re-register` button for cancelled registrations
- Reads `is_mandatory` from registration data

**New File: `add-participant-form.tsx`:**
- Searchable profile picker with dropdown
- Filters out already-registered users
- Calls `adminManualRegister` on submit