### PR TITLE
fix: UI visual polish — mobile sidebar, empty states, cleanup

### DIFF
--- a/app/admin/events/[id]/registrations/page.tsx
+++ b/app/admin/events/[id]/registrations/page.tsx
@@ -34,7 +34,10 @@ function AttendeeList({
       </h2>
       <div className="overflow-hidden rounded-[24px] border border-camp-forest/10 bg-white/85 p-1 shadow-panel">
         {attendees.length === 0 ? (
-          <p className="p-4 text-sm text-slate-500">No attendees.</p>
+          <div className="p-6 text-center">
+            <p className="text-3xl">👥</p>
+            <p className="mt-2 text-sm text-slate-500">No attendees registered yet.</p>
+          </div>
         ) : (
           <div className="divide-y divide-slate-200">
             {attendees.map((a: any) => (

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -46,7 +46,17 @@ export default async function AdminEventsPage() {
             </Link>
           ))
         ) : (
-          <p className="text-sm text-slate-500">No events found.</p>
+          <div className="rounded-[24px] border border-dashed border-camp-forest/10 bg-white/60 p-8 text-center">
+            <p className="text-4xl">📅</p>
+            <p className="mt-3 font-serif text-lg text-camp-forest">No events yet</p>
+            <p className="mt-1 text-sm text-slate-500">Get started by creating your first event.</p>
+            <Link
+              href="/admin/events/new"
+              className="mt-4 inline-block rounded-full bg-camp-forest px-5 py-2 text-sm font-medium text-white transition hover:bg-camp-forest/90"
+            >
+              + Create Event
+            </Link>
+          </div>
         )}
       </div>
     </AppShell>

--- a/app/check-in/check-in-list.tsx
+++ b/app/check-in/check-in-list.tsx
@@ -32,7 +32,13 @@ export function CheckInList({ registrations }: { registrations: EventRegistratio
   return (
     <div className="grid gap-4">
       {registrations.length === 0 ? (
-        <p className="text-sm text-slate-500">No active registrations found.</p>
+        <div className="rounded-[24px] border border-dashed border-camp-forest/10 bg-white/60 p-8 text-center">
+          <p className="text-4xl">✅</p>
+          <p className="mt-3 font-serif text-lg text-camp-forest">No active registrations</p>
+          <p className="mt-1 text-sm text-slate-500">
+            There are no confirmed registrations to check in.
+          </p>
+        </div>
       ) : (
         registrations.map((reg) => {
           const name = reg.user

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -80,7 +80,11 @@ export default async function EventsPage({ searchParams }: EventsPageProps) {
 
       <div className="grid gap-4">
         {(events || []).length === 0 ? (
-          <p className="text-sm text-slate-500">No events found.</p>
+          <div className="rounded-[24px] border border-dashed border-camp-forest/10 bg-white/60 p-8 text-center">
+            <p className="text-4xl">📅</p>
+            <p className="mt-3 font-serif text-lg text-camp-forest">No events yet</p>
+            <p className="mt-1 text-sm text-slate-500">Check back soon for upcoming events.</p>
+          </div>
         ) : (
           (events || []).map((event) => (
             <Link

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
-    <html lang="en">
+    <html lang="en-GB">
       <body>{children}</body>
     </html>
   );

--- a/app/tasks/task-list.tsx
+++ b/app/tasks/task-list.tsx
@@ -257,7 +257,8 @@ export function TaskList({
       <div className="grid gap-4">
         {filteredTasks.length === 0 ? (
           <div className="rounded-[24px] border border-dashed border-slate-200 bg-white/60 p-8 text-center">
-            <p className="text-sm text-slate-500">
+            <p className="text-4xl">📋</p>
+            <p className="mt-3 text-sm text-slate-500">
               {filter === 'mine'
                 ? 'No tasks assigned to you.'
                 : filter === 'active'

--- a/components/layout/app-shell.tsx
+++ b/components/layout/app-shell.tsx
@@ -1,4 +1,5 @@
 import { SignOutButton } from '@/components/auth/sign-out-button';
+import { MobileSidebar } from '@/components/layout/mobile-sidebar';
 import { SidebarNav } from '@/components/layout/sidebar-nav';
 import { navItems } from '@/lib/app-config';
 import { getSession } from '@/lib/auth/session';
@@ -12,19 +13,20 @@ type AppShellProps = {
 export async function AppShell({ title, eyebrow, children }: AppShellProps) {
   const session = await getSession();
 
+  const filteredNav = navItems.filter(
+    (item) => session.isAuthenticated && (!item.roles || item.roles.includes(session.role))
+  );
+
   return (
     <div className="min-h-screen bg-[radial-gradient(circle_at_top_left,_rgba(217,237,246,0.75),_transparent_32%),linear-gradient(180deg,_#fcfcf7_0%,_#f6f0df_100%)] text-slate-950">
       <div className="mx-auto flex min-h-screen max-w-7xl flex-col gap-6 px-4 py-4 lg:flex-row lg:px-8">
-        <aside className="w-full rounded-[28px] border border-camp-forest/10 bg-white/80 p-5 shadow-panel backdrop-blur lg:sticky lg:top-4 lg:flex lg:max-h-[calc(100vh-2rem)] lg:w-80 lg:flex-col lg:overflow-hidden">
-          <div className="rounded-[24px] bg-camp-forest p-5 text-white">
+        <MobileSidebar>
+          <div className="rounded-[24px] bg-camp-forest p-4 text-white">
             <p className="text-xs uppercase tracking-[0.3em] text-camp-sky">Camp Ops</p>
-            <h1 className="mt-3 font-serif text-3xl">Infrastructure Scaffold</h1>
-            <p className="mt-3 text-sm text-white/80">
-              Minimal shell for events, tasks, check-in, and role-aware navigation.
-            </p>
+            <h1 className="mt-2 font-serif text-2xl">Camp Management</h1>
           </div>
 
-          <div className="mt-5 rounded-[24px] border border-camp-forest/10 bg-camp-sand/60 p-4 text-sm">
+          <div className="mt-4 rounded-[24px] border border-camp-forest/10 bg-camp-sand/60 p-3 text-sm">
             <p className="font-semibold text-camp-forest">{session.displayName}</p>
             <p className="text-slate-700">{session.email}</p>
             <p className="mt-2 inline-flex rounded-full bg-white px-3 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-camp-forest">
@@ -33,12 +35,7 @@ export async function AppShell({ title, eyebrow, children }: AppShellProps) {
           </div>
 
           <div className="mt-5 flex min-h-0 flex-1 flex-col">
-            <SidebarNav
-              items={navItems.filter(
-                (item) =>
-                  session.isAuthenticated && (!item.roles || item.roles.includes(session.role))
-              )}
-            />
+            <SidebarNav items={filteredNav} />
 
             {session.isAuthenticated && (
               <div className="mt-4 border-t border-camp-forest/10 pt-4">
@@ -46,23 +43,12 @@ export async function AppShell({ title, eyebrow, children }: AppShellProps) {
               </div>
             )}
           </div>
-        </aside>
+        </MobileSidebar>
 
         <main className="flex-1">
           <header className="rounded-[28px] border border-camp-forest/10 bg-white/85 p-6 shadow-panel backdrop-blur">
             <p className="text-xs uppercase tracking-[0.3em] text-camp-moss">{eyebrow}</p>
-            <div className="mt-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
-              <div>
-                <h2 className="font-serif text-4xl text-camp-forest">{title}</h2>
-                <p className="mt-2 max-w-2xl text-slate-600">
-                  Demo auth keeps the shell usable immediately. Supabase helpers and route
-                  boundaries are ready to wire into a real project as soon as keys are added.
-                </p>
-              </div>
-              <div className="rounded-2xl bg-camp-sky px-4 py-3 text-sm text-camp-forest">
-                Mode: <span className="font-semibold">{session.mode}</span>
-              </div>
-            </div>
+            <h2 className="mt-3 font-serif text-4xl text-camp-forest">{title}</h2>
           </header>
 
           <section className="mt-6">{children}</section>

--- a/components/layout/mobile-sidebar.tsx
+++ b/components/layout/mobile-sidebar.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { usePathname } from 'next/navigation';
+
+import { cn } from '@/lib/utils';
+
+export function MobileSidebar({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const pathname = usePathname();
+
+  // Close sidebar on route change
+  useEffect(() => {
+    setIsOpen(false);
+  }, [pathname]);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = '';
+    }
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [isOpen]);
+
+  const close = useCallback(() => setIsOpen(false), []);
+
+  return (
+    <>
+      {/* Mobile hamburger — only visible below lg */}
+      <button
+        type="button"
+        onClick={() => setIsOpen((o) => !o)}
+        className="fixed left-4 top-4 z-50 flex h-10 w-10 items-center justify-center rounded-full bg-camp-forest text-lg text-white shadow-lg transition hover:bg-camp-forest/90 lg:hidden"
+        aria-label={isOpen ? 'Close navigation' : 'Open navigation'}
+      >
+        {isOpen ? '✕' : '☰'}
+      </button>
+
+      {/* Backdrop overlay */}
+      <div
+        className={cn(
+          'fixed inset-0 z-40 bg-black/40 backdrop-blur-sm transition-opacity lg:hidden',
+          isOpen ? 'opacity-100' : 'pointer-events-none opacity-0'
+        )}
+        onClick={close}
+        aria-hidden="true"
+      />
+
+      {/* Sidebar drawer (mobile) / static aside (desktop) */}
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-40 flex w-80 max-w-[85vw] flex-col overflow-y-auto rounded-r-[28px] border-r border-camp-forest/10 bg-white/95 p-5 shadow-panel backdrop-blur transition-transform duration-300 ease-in-out',
+          isOpen ? 'translate-x-0' : '-translate-x-full',
+          'lg:static lg:sticky lg:top-4 lg:z-auto lg:max-h-[calc(100vh-2rem)] lg:translate-x-0 lg:overflow-hidden lg:rounded-[28px] lg:border lg:bg-white/80 lg:shadow-panel'
+        )}
+      >
+        {children}
+      </aside>
+    </>
+  );
+}

--- a/components/layout/sidebar-nav.tsx
+++ b/components/layout/sidebar-nav.tsx
@@ -36,7 +36,7 @@ export function SidebarNav({ items }: { items: NavItem[] }) {
       onScroll={(event) => {
         window.sessionStorage.setItem(SIDEBAR_SCROLL_KEY, String(event.currentTarget.scrollTop));
       }}
-      className="space-y-2 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1"
+      className="space-y-1 lg:min-h-0 lg:flex-1 lg:overflow-y-auto lg:pr-1"
     >
       {items.map((item) => {
         const isActive = isActivePath(pathname, item.href);
@@ -48,12 +48,12 @@ export function SidebarNav({ items }: { items: NavItem[] }) {
             scroll={false}
             aria-current={isActive ? 'page' : undefined}
             className={cn(
-              'block rounded-2xl border border-transparent px-4 py-3 transition hover:border-camp-forest/20 hover:bg-white',
+              'block rounded-xl border border-transparent px-3 py-2 transition hover:border-camp-forest/20 hover:bg-white',
               isActive && 'border-camp-forest/15 bg-white'
             )}
           >
             <span className="block font-semibold text-camp-forest">{item.label}</span>
-            <span className="block text-sm text-slate-600">{item.description}</span>
+            <span className="block text-xs text-slate-600">{item.description}</span>
           </Link>
         );
       })}


### PR DESCRIPTION
## Changes

### 1. Mobile collapsible sidebar
- Hamburger toggle on mobile (below lg: breakpoint)
- Slide-in drawer with backdrop overlay + blur
- Auto-closes on nav click and route change
- Desktop layout unchanged

### 2. Sidebar nav overflow fixed
- Reduced nav item padding and gap so all items fit without scrolling

### 3. Removed scaffolding/demo banner
- Removed 'Demo auth keeps the shell usable...' text and 'Mode: supabase' pill
- Renamed sidebar title to 'Camp Management'

### 4. Better empty states
- Events, Admin Events, Registrations, Check-in, Tasks — emoji icons + friendly messages + CTAs

### 5. Date format
- `lang="en-GB"` on root html element for DD/MM/YYYY defaults

### 6. Mandatory participants selector
- Already had max-height from PR #76 — no change needed