### PR TITLE
feat: Fluid nature-inspired loading screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -27,3 +27,175 @@ a {
   color: inherit;
   text-decoration: none;
 }
+
+/* ═══════════════════════════════════════════════════════════════
+   Camp Loading Screen — fluid, nature-inspired animations
+   ═══════════════════════════════════════════════════════════════ */
+
+/* ── Gradient orbs ──────────────────────────────────────────── */
+.loading-orb {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(80px);
+  will-change: transform, opacity;
+}
+.loading-orb-1 {
+  width: 420px;
+  height: 420px;
+  background: radial-gradient(circle, rgba(15,61,46,0.10) 0%, transparent 70%);
+  top: -10%;
+  left: -8%;
+  animation: orbDrift1 12s ease-in-out infinite;
+}
+.loading-orb-2 {
+  width: 340px;
+  height: 340px;
+  background: radial-gradient(circle, rgba(210,106,57,0.08) 0%, transparent 70%);
+  bottom: -5%;
+  right: -5%;
+  animation: orbDrift2 14s ease-in-out infinite;
+}
+.loading-orb-3 {
+  width: 280px;
+  height: 280px;
+  background: radial-gradient(circle, rgba(217,237,246,0.25) 0%, transparent 70%);
+  top: 30%;
+  left: 50%;
+  transform: translateX(-50%);
+  animation: orbDrift3 10s ease-in-out infinite;
+}
+.loading-orb-4 {
+  width: 500px;
+  height: 500px;
+  background: radial-gradient(circle, rgba(244,232,193,0.20) 0%, transparent 70%);
+  top: 50%;
+  left: 20%;
+  animation: orbDrift4 16s ease-in-out infinite;
+}
+
+@keyframes orbDrift1 {
+  0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.7; }
+  50% { transform: translate(60px, 40px) scale(1.15); opacity: 1; }
+}
+@keyframes orbDrift2 {
+  0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.6; }
+  50% { transform: translate(-50px, -30px) scale(1.1); opacity: 0.9; }
+}
+@keyframes orbDrift3 {
+  0%, 100% { transform: translateX(-50%) translateY(0) scale(1); opacity: 0.5; }
+  50% { transform: translateX(-50%) translateY(-30px) scale(1.08); opacity: 0.8; }
+}
+@keyframes orbDrift4 {
+  0%, 100% { transform: translate(0, 0) scale(1); opacity: 0.4; }
+  50% { transform: translate(40px, -50px) scale(1.12); opacity: 0.6; }
+}
+
+/* ── Wave animation ─────────────────────────────────────────── */
+.loading-wave {
+  height: 120px;
+}
+.loading-wave-path-1 {
+  animation: waveSway1 6s ease-in-out infinite;
+}
+.loading-wave-path-2 {
+  animation: waveSway2 8s ease-in-out infinite;
+}
+.loading-wave-path-3 {
+  animation: waveSway3 10s ease-in-out infinite;
+}
+
+@keyframes waveSway1 {
+  0%, 100% { d: path("M0,120 C240,180 480,60 720,120 C960,180 1200,60 1440,120 L1440,220 L0,220 Z"); }
+  50% { d: path("M0,130 C240,70 480,170 720,110 C960,60 1200,170 1440,130 L1440,220 L0,220 Z"); }
+}
+@keyframes waveSway2 {
+  0%, 100% { d: path("M0,140 C240,80 480,200 720,140 C960,80 1200,200 1440,140 L1440,220 L0,220 Z"); }
+  50% { d: path("M0,150 C240,200 480,90 720,150 C960,200 1200,90 1440,150 L1440,220 L0,220 Z"); }
+}
+@keyframes waveSway3 {
+  0%, 100% { d: path("M0,160 C360,200 720,120 1080,160 C1260,180 1380,150 1440,160 L1440,220 L0,220 Z"); }
+  50% { d: path("M0,170 C360,130 720,190 1080,150 C1260,140 1380,170 1440,170 L1440,220 L0,220 Z"); }
+}
+
+/* ── Logo entrance + breathing ──────────────────────────────── */
+.loading-logo-entrance {
+  animation: logoFloat 0.8s cubic-bezier(0.22, 1, 0.36, 1) forwards,
+             logoBreathe 4s ease-in-out 0.8s infinite;
+  opacity: 0;
+  transform: translateY(16px) scale(0.9);
+}
+@keyframes logoFloat {
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes logoBreathe {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-4px) scale(1.02); }
+}
+
+/* ── Sun glow pulse ─────────────────────────────────────────── */
+.loading-sun {
+  animation: sunPulse 3s ease-in-out infinite;
+  transform-origin: 50px 20px;
+}
+@keyframes sunPulse {
+  0%, 100% { opacity: 0.85; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.18); }
+}
+
+/* ── Title / subtitle entrance ──────────────────────────────── */
+.loading-title-entrance {
+  animation: loadingSlideUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.2s forwards;
+  opacity: 0;
+  transform: translateY(12px);
+}
+.loading-subtitle-entrance {
+  animation: loadingSlideUp 0.7s cubic-bezier(0.22, 1, 0.36, 1) 0.4s forwards;
+  opacity: 0;
+  transform: translateY(12px);
+}
+@keyframes loadingSlideUp {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Flowing dots ───────────────────────────────────────────── */
+.loading-dot {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: #0f3d2e;
+  opacity: 0.35;
+}
+.loading-dot-1 { animation: dotFlow 1.6s ease-in-out infinite; }
+.loading-dot-2 { animation: dotFlow 1.6s ease-in-out 0.2s infinite; }
+.loading-dot-3 { animation: dotFlow 1.6s ease-in-out 0.4s infinite; }
+
+@keyframes dotFlow {
+  0%, 100% {
+    opacity: 0.25;
+    transform: translateY(0) scale(0.85);
+  }
+  50% {
+    opacity: 0.9;
+    transform: translateY(-6px) scale(1.15);
+  }
+}
+
+/* ── Reduced motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  .loading-orb,
+  .loading-wave-path-1,
+  .loading-wave-path-2,
+  .loading-wave-path-3,
+  .loading-sun,
+  .loading-logo-entrance,
+  .loading-dot {
+    animation: none !important;
+  }
+  .loading-logo-entrance,
+  .loading-title-entrance,
+  .loading-subtitle-entrance {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+}

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,5 @@
+import { CampLoadingScreen } from '@/components/layout/camp-loading-screen';
+
+export default function RootLoading() {
+  return <CampLoadingScreen />;
+}

--- a/components/layout/camp-loading-screen.tsx
+++ b/components/layout/camp-loading-screen.tsx
@@ -1,0 +1,96 @@
+/**
+ * components/layout/camp-loading-screen.tsx
+ *
+ * Fluid, nature-inspired full-page loading screen.
+ * Shown during auth verification and initial page loads.
+ *
+ * All animations are defined in globals.css as @keyframes
+ * so this can remain a Server Component (no styled-jsx).
+ *
+ * Design tokens from DESIGN.md:
+ *   - camp-cream (#faf6ee) canvas
+ *   - camp-forest (#0f3d2e) primary
+ *   - camp-moss (#4f7a5c) secondary
+ *   - camp-ember (#d26a39) accent
+ *   - camp-sand (#f4e8c1) soft surface
+ *   - camp-sky (#d9edf6) info tint
+ *   - DM Serif Display for headings
+ *   - Inter for body
+ */
+
+export function CampLoadingScreen() {
+  return (
+    <div className="fixed inset-0 z-[200] flex items-center justify-center overflow-hidden bg-camp-cream">
+      {/* ── Animated background layers ─────────────────────────── */}
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="loading-orb loading-orb-1" />
+        <div className="loading-orb loading-orb-2" />
+        <div className="loading-orb loading-orb-3" />
+        <div className="loading-orb loading-orb-4" />
+      </div>
+
+      {/* ── Wave layers at the bottom ─────────────────────────── */}
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0" aria-hidden="true">
+        <svg
+          className="loading-wave w-full"
+          viewBox="0 0 1440 220"
+          preserveAspectRatio="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            className="loading-wave-path-1"
+            d="M0,120 C240,180 480,60 720,120 C960,180 1200,60 1440,120 L1440,220 L0,220 Z"
+            fill="rgba(15,61,46,0.06)"
+          />
+          <path
+            className="loading-wave-path-2"
+            d="M0,140 C240,80 480,200 720,140 C960,80 1200,200 1440,140 L1440,220 L0,220 Z"
+            fill="rgba(15,61,46,0.04)"
+          />
+          <path
+            className="loading-wave-path-3"
+            d="M0,160 C360,200 720,120 1080,160 C1260,180 1380,150 1440,160 L1440,220 L0,220 Z"
+            fill="rgba(79,122,92,0.05)"
+          />
+        </svg>
+      </div>
+
+      {/* ── Centered content ──────────────────────────────────── */}
+      <div className="relative z-10 flex flex-col items-center">
+        {/* App icon — mountain + sun silhouette */}
+        <div className="loading-logo-entrance mb-6">
+          <svg
+            width="72"
+            height="72"
+            viewBox="0 0 72 72"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            className="drop-shadow-sm"
+          >
+            <circle cx="50" cy="20" r="8" className="loading-sun" fill="#d26a39" opacity="0.85" />
+            <path d="M8 58 L30 18 L52 58 Z" fill="#4f7a5c" opacity="0.5" />
+            <path d="M20 58 L44 22 L68 58 Z" fill="#0f3d2e" opacity="0.85" />
+            <path d="M38 30 L44 22 L50 30 Z" fill="#faf6ee" opacity="0.9" />
+          </svg>
+        </div>
+
+        {/* App name */}
+        <h1 className="loading-title-entrance font-serif text-3xl tracking-tight text-camp-forest sm:text-4xl">
+          COCM Camp
+        </h1>
+
+        {/* Subtitle */}
+        <p className="loading-subtitle-entrance mt-2 text-sm font-medium text-camp-moss/70">
+          Preparing your workspace…
+        </p>
+
+        {/* Flowing loading indicator — 3 morphing dots */}
+        <div className="mt-8 flex items-center gap-2">
+          <span className="loading-dot loading-dot-1" />
+          <span className="loading-dot loading-dot-2" />
+          <span className="loading-dot loading-dot-3" />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
Adds a fluid, nature-inspired full-page loading screen shown during auth verification and initial page loads.

## Design
All tokens from DESIGN.md:
- Background: camp-cream canvas
- Gradient orbs: forest, ember, sky, sand — blurred blobs that drift organically
- Wave layers: 3 SVG paths at the bottom with independent sway animations
- Logo: Mountain + sun silhouette with breathing animation and sun glow pulse
- Typography: DM Serif Display heading, Inter subtitle — staggered entrance
- Loading dots: 3 pulsing dots with sequential delay

## Animations
All pure CSS @keyframes — zero JS animation libraries.
- Orb drift (12-16s cycles), Wave sway (6-10s cycles)
- Logo float-in + breathing, Title/subtitle slide-up entrance
- Dot flow pulse, prefers-reduced-motion respected

## Files Changed
- app/loading.tsx — root loading boundary
- app/globals.css — animation keyframes
- components/layout/camp-loading-screen.tsx — the screen component